### PR TITLE
Master bdcs mddb volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ d = ${PWD}
 endif
 
 importer:
-	docker build -t build-img -f Dockerfile.build .
-	docker create --name build-cont build-img
+	docker build -t wiggum/build-img -f Dockerfile.build .
+	docker create --name build-cont wiggum/build-img
 	docker cp build-cont:/root/.cabal/bin/import ./import
 	docker rm build-cont
-	docker build -t import-img .
+	docker build -t wiggum/import-img .
 
 mddb:
 	docker volume create -d local --opt o=size=2GB --name bdcs-mddb-volume
-	docker run -v bdcs-mddb-volume:/mddb -v ${d}/rpms:/rpms:ro --rm import-img
+	docker run -v bdcs-mddb-volume:/mddb -v ${d}/rpms:/rpms:ro --rm wiggum/import-img
 
 .PHONY: importer mddb


### PR DESCRIPTION
This changes make mddb to create a 2GB docker volume named bdcs-mddb-volume, and to use it when importing the rpms. It also changes image creation to use the wiggum/* namespace so that there are no naming collisions with the docker hub.
