### PR TITLE
Rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 d = ${PWD}
 endif
 
-ORG_NAME=wiggum
+ORG_NAME=weld
 
 importer:
 	docker build -t $(ORG_NAME)/build-img -f Dockerfile.build .

--- a/README
+++ b/README
@@ -38,7 +38,7 @@ that image and produces the mddb.
 
 The Dockerfile depends on a base image, named weld/fedora:24, which needs have
 been previously built. If it is not available it can be built from the
-composer-deployment repository by running `make weld-f24`.
+welder-deployment repository by running `make weld-f24`.
 
 The Makefile lays out the exact steps and can be used to simplify all this -
 just run "make importer mddb".  If make is unavailable, just copy the steps


### PR DESCRIPTION
Rename things from 'wiggum' to 'weld' or 'welder'.

The reference to 'welder-deployment' will be wrong until we actually rename the repo, but I can't do that in a PR, so.. consider that part of the changes when reviewing, I guess?

See also: https://github.com/wiggum/composer-deployment/pull/7