### PR TITLE
Bump the minimum version of base to 4.9

### DIFF
--- a/importer/db.cabal
+++ b/importer/db.cabal
@@ -37,7 +37,7 @@ library
                        Import.Repodata,
                        Import.State
 
-  build-depends:       base >=4.8 && <5.0,
+  build-depends:       base >=4.9 && <5.0,
                        bytestring,
                        cond,
                        conduit >= 1.2.8,


### PR DESCRIPTION
This is needed for the latest version of esqueleto and the glib
bindings.