### PR TITLE
Make it easier to import CentOS metadata

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
-if [ ! -f /mddb/metadata.db ]; then
-    sqlite3 /mddb/metadata.db < /root/schema.sql
+MDDB="/mddb/metadata.db"
+
+if [[ -e "$MDDB" && -z "$KEEP_MDDB" ]]; then
+    rm "$MDDB"
+fi
+
+if [ ! -f "$MDDB" ]; then
+    sqlite3 "$MDDB" < /root/schema.sql
 fi
 
 for f in /rpms/*rpm; do
-    /usr/local/bin/import /mddb/metadata.db cs.repo file://${f}
+    /usr/local/bin/import "$MDDB" cs.repo file://${f}
 done
+
+# if URL was passed try to import from there
+if [ -n "$IMPORT_URL" ]; then
+    /usr/local/bin/import "$MDDB" cs.repo $IMPORT_URL
+fi

--- a/primary-xml-gz
+++ b/primary-xml-gz
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import sys
+import urllib
+import xml.etree.ElementTree as ET
+
+if __name__ == "__main__":
+    repo_url = sys.argv[1]
+    response = urllib.urlopen(repo_url + '/repodata/repomd.xml')
+    xml = response.read()
+    xml = ET.fromstring(xml)
+    for data in xml:
+        if data.tag.endswith('data') and 'type' in data.attrib and \
+           data.attrib['type'] == 'primary':
+            break
+    else:
+        raise Exception('Cannot find primary.xml')
+
+    for child in data:
+        if child.tag.endswith('location'):
+            print repo_url + '/' + child.attrib['href']


### PR DESCRIPTION
- use env variables to control import
- add make target to build F25 docker image if not present
- copy the new metadata.db out of the volume
- new helper script & Makefile target to import CentOS 7