### PR TITLE
Cut down on code duplication in the import functions

### DIFF
--- a/importer/Import/Comps.hs
+++ b/importer/Import/Comps.hs
@@ -91,7 +91,7 @@ loadFromURL metadataRequest = do
     -- code doesn't get lost.
     return ()
  where
-    readMetadataPipeline request = getFromURL request .| ungzipIfCompressed (C8.unpack $ path request) .| sinkDoc def
+    readMetadataPipeline request = getFromURL request .| ungzipIfCompressed .| sinkDoc def
 
 loadFromFile :: FilePath -> ReaderT ImportState IO ()
 loadFromFile metadataPath = do
@@ -101,4 +101,4 @@ loadFromFile metadataPath = do
     -- code doesn't get lost.
     return ()
  where
-    readMetadataPipeline p = getFromFile p .| ungzipIfCompressed p .| sinkDoc def
+    readMetadataPipeline p = getFromFile p .| ungzipIfCompressed .| sinkDoc def

--- a/importer/Import/Repodata.hs
+++ b/importer/Import/Repodata.hs
@@ -19,33 +19,29 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Import.Repodata(RepoException,
-                       loadFromFile,
-                       loadFromURL,
-                       loadRepoFromFile,
-                       loadRepoFromURL)
+                       loadFromURI,
+                       loadRepoFromURI)
  where
 
 import           Control.Applicative((<|>))
 import           Control.Exception(Exception)
+import           Control.Monad.IO.Class(MonadIO)
 import           Control.Monad.Reader(ReaderT)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as C8
+import           Control.Monad.Trans.Resource(MonadBaseControl, MonadThrow)
 import           Data.Conduit((.|), runConduitRes)
 import           Data.Data(Typeable)
-import           Data.Maybe(listToMaybe)
+import           Data.Maybe(fromJust, listToMaybe)
 import qualified Data.Text as T
-import           Data.Text.Encoding(encodeUtf8)
-import           Network.HTTP.Conduit(path)
-import           Network.HTTP.Simple(Request, setRequestPath)
-import           System.FilePath((</>), dropDrive, takeDirectory)
+import           Network.URI(URI(..), parseURIReference, relativeTo)
 import           Text.XML(Document, sinkDoc)
 import           Text.XML.Cursor
 import           Text.XML.Stream.Parse(def)
 
 import qualified Import.Comps as Comps
-import           Import.Conduit(getFromFile, getFromURL, ungzipIfCompressed)
+import           Import.Conduit(getFromURI, ungzipIfCompressed)
 import qualified Import.RPM as RPM
 import           Import.State(ImportState(..))
+import           Import.URI(appendURI)
 
 import           BDCS.Exceptions(throwIfNothing)
 
@@ -75,71 +71,40 @@ extractType doc dataType = let
                             laxElement "location" >=>
                             attribute "href"
 
-loadRepoFromURL :: Request -> ReaderT ImportState IO ()
-loadRepoFromURL baseRequest = do
+-- fetch and parse an XML document
+fetchAndParse :: (MonadThrow m, MonadIO m, MonadBaseControl IO m) => URI -> m Document
+fetchAndParse uri = runConduitRes $ getFromURI uri .| ungzipIfCompressed .| sinkDoc def
+
+loadRepoFromURI :: URI -> ReaderT ImportState IO ()
+loadRepoFromURI uri = do
     -- Fetch and parse repomd.xml
-    repomd <- runConduitRes $ getFromURL (appendPath "repodata/repomd.xml") .| sinkDoc def
+    repomd <- fetchAndParse (appendOrThrow "repodata/repomd.xml")
 
     -- Import primary.xml
     let primary = throwIfNothing (extractType repomd "primary") RepoException
-    loadFromURL $ appendPath primary
+    loadFromURI $ appendOrThrow primary
 
     -- Import comps if it exists
     -- Try group_gz, then group. If neither exists group will be Nothing, which is fine, just skip it
     let group = extractType repomd "group_gz" <|> extractType repomd "group"
-    let groupRequest = fmap appendPath group
-    case groupRequest of
-        Just r  -> Comps.loadFromURL r
+    let groupURI = fmap appendOrThrow group
+    case groupURI of
+        Just u -> Comps.loadFromURI u
         Nothing -> return ()
-
  where
-    -- append a path to the base URL
-    appendPath :: T.Text -> Request
-    appendPath p = let
-        -- If the base request path already ends in a slash, don't add an extra one
-        basePath = path baseRequest
-        basePathSlash = if C8.last basePath == '/' then basePath else basePath `BS.append` "/"
-     in
-        setRequestPath (basePathSlash `BS.append` encodeUtf8 p) baseRequest
+    appendOrThrow :: T.Text -> URI
+    appendOrThrow path = throwIfNothing (appendURI uri (T.unpack path)) RepoException
 
-loadRepoFromFile :: FilePath -> ReaderT ImportState IO ()
-loadRepoFromFile baseFile = do
-    -- Fetch and parse repomd.xml
-    repomd <- runConduitRes $ getFromFile (appendPath "repodata/repomd.xml") .| sinkDoc def
-
-    -- Import primary.xml
-    let primary = throwIfNothing (extractType repomd "primary") RepoException
-    loadFromFile $ appendPath primary
-
-    -- Import comps if it exists
-    -- Try group_gz, then group. If neither exists group will be Nothing, which is fine, just skip it
-    let group = extractType repomd "group_gz" <|> extractType repomd "group"
-    let groupRequest = fmap appendPath group
-    case groupRequest of
-        Just r  -> Comps.loadFromFile r
-        Nothing -> return ()
-
+loadFromURI :: URI -> ReaderT ImportState IO ()
+loadFromURI metadataURI = do
+    document <- fetchAndParse metadataURI
+    let locations = map appendOrThrow $ extractLocations document
+    mapM_ RPM.loadFromURI locations
  where
-    -- append a path to the base URL
-    appendPath :: T.Text -> FilePath
-    appendPath p = let
-        -- use dropDrive to remove the leading / from the path
-        p' = dropDrive (T.unpack p)
-     in
-        baseFile </> p'
+    -- the path is, e.g., /path/to/repo/repodata/primary.xml. Go up one directory.
+    baseURI :: URI
+    baseURI = let upOne = fromJust $ parseURIReference ".." in
+        relativeTo upOne metadataURI
 
-
-loadFromURL :: Request -> ReaderT ImportState IO ()
-loadFromURL metadataRequest = do
-    let (basePath, _) = BS.breakSubstring "repodata/" (path metadataRequest)
-    locations <- map (\p -> metadataRequest { path=BS.concat [basePath, encodeUtf8 p] }) <$> extractLocations <$> runConduitRes (readMetadataPipeline metadataRequest)
-    mapM_ RPM.loadFromURL locations
- where
-    readMetadataPipeline request = getFromURL request .| ungzipIfCompressed .| sinkDoc def
-
-loadFromFile :: FilePath -> ReaderT ImportState IO ()
-loadFromFile metadataPath = do
-    locations <- map (\p -> (takeDirectory . takeDirectory) metadataPath </> T.unpack p) <$> extractLocations <$> runConduitRes (readMetadataPipeline metadataPath)
-    mapM_ RPM.loadFromFile locations
- where
-    readMetadataPipeline p = getFromFile p .| ungzipIfCompressed .| sinkDoc def
+    appendOrThrow :: T.Text -> URI
+    appendOrThrow path = throwIfNothing (appendURI baseURI (T.unpack path)) RepoException

--- a/importer/Import/Repodata.hs
+++ b/importer/Import/Repodata.hs
@@ -135,11 +135,11 @@ loadFromURL metadataRequest = do
     locations <- map (\p -> metadataRequest { path=BS.concat [basePath, encodeUtf8 p] }) <$> extractLocations <$> runConduitRes (readMetadataPipeline metadataRequest)
     mapM_ RPM.loadFromURL locations
  where
-    readMetadataPipeline request = getFromURL request .| ungzipIfCompressed (C8.unpack $ path request) .| sinkDoc def
+    readMetadataPipeline request = getFromURL request .| ungzipIfCompressed .| sinkDoc def
 
 loadFromFile :: FilePath -> ReaderT ImportState IO ()
 loadFromFile metadataPath = do
     locations <- map (\p -> (takeDirectory . takeDirectory) metadataPath </> T.unpack p) <$> extractLocations <$> runConduitRes (readMetadataPipeline metadataPath)
     mapM_ RPM.loadFromFile locations
  where
-    readMetadataPipeline p = getFromFile p .| ungzipIfCompressed p .| sinkDoc def
+    readMetadataPipeline p = getFromFile p .| ungzipIfCompressed .| sinkDoc def

--- a/importer/db.cabal
+++ b/importer/db.cabal
@@ -34,7 +34,8 @@ library
                        Import.Conduit,
                        Import.RPM,
                        Import.Repodata,
-                       Import.State
+                       Import.State,
+                       Import.URI
 
   build-depends:       base >=4.9 && <5.0,
                        bytestring,
@@ -54,6 +55,7 @@ library
                        http-conduit,
                        lzma-conduit,
                        mtl >= 2.2.1,
+                       network-uri,
                        persistent,
                        persistent-sqlite,
                        persistent-template,


### PR DESCRIPTION
Remove the filename parameter from ungzipIfCompressed to simplify the pipelines, and instead of having two load functions that do basically the same thing, redo them as a single function that takes a URI and a function in Import.Conduit that figures out what to do with it.