### PR TITLE
Change a call to match an ostree API change

### DIFF
--- a/importer/BDCS/CS.hs
+++ b/importer/BDCS/CS.hs
@@ -67,7 +67,7 @@ commit repo repoFile subject body =
         -- ostree will know what to do.
         parent <- parentCommit repo "master"
         checksum <- repoWriteCommit repo parent (Just subject) body Nothing root noCancellable
-        repoTransactionSetRef repo Nothing "master" checksum
+        repoTransactionSetRef repo Nothing "master" (Just checksum)
         return checksum
 
 -- Given an open ostree repo and a checksum to some commit, return a ChecksumMap.  This is useful for


### PR DESCRIPTION
As of version 2017.6, the last argument of
ostree_repo_transaction_set_ref now has a "nullable" annotation,
changing the type for Haskell from Text to Maybe Text. Add a Just
accordingly.