### PR TITLE
Add git describe version info to the usage output

### DIFF
--- a/importer/BDCS/Version.hs
+++ b/importer/BDCS/Version.hs
@@ -1,0 +1,33 @@
+-- Copyright (C) 2017 Red Hat, Inc.
+--
+-- This library is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU Lesser General Public
+-- License as published by the Free Software Foundation; either
+-- version 2.1 of the License, or (at your option) any later version.
+--
+-- This library is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-- Lesser General Public License for more details.
+--
+-- You should have received a copy of the GNU Lesser General Public
+-- License along with this library; if not, see <http://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
+
+module BDCS.Version(printVersion)
+  where
+
+import Data.Version (showVersion)
+import Development.GitRev
+import Text.Printf(printf)
+
+import Paths_db (version)
+
+
+printVersion :: String -> IO ()
+printVersion toolName = do
+    let git_version = $(gitDescribe)
+    if git_version == "UNKNOWN" then
+        printf "%s v%s\n" toolName $ showVersion version
+    else
+        printf "%s %s\n" toolName git_version

--- a/importer/db.cabal
+++ b/importer/db.cabal
@@ -34,6 +34,7 @@ library
                        BDCS.RPM.Requirements,
                        BDCS.RPM.Signatures,
                        BDCS.RPM.Sources,
+                       BDCS.Version,
                        Import.Comps,
                        Import.Conduit,
                        Import.RPM,
@@ -58,6 +59,7 @@ library
                        gi-gio,
                        gi-glib,
                        gi-ostree,
+                       gitrev,
                        haskell-gi-base,
                        http-conduit,
                        lzma-conduit,
@@ -73,6 +75,7 @@ library
                        time,
                        transformers,
                        xml-conduit
+  other-modules:       Paths_db
   default-language:    Haskell2010
 
 executable import

--- a/importer/tools/depclose.hs
+++ b/importer/tools/depclose.hs
@@ -60,6 +60,7 @@ import           System.Environment(getArgs)
 import           System.Exit(exitFailure)
 
 import BDCS.DB
+import BDCS.Version
 
 data Proposition = T.Text `Obsoletes` T.Text
                  | NEVRA  `Provides`  T.Text
@@ -267,6 +268,7 @@ main = do
     argv <- getArgs
 
     when (length argv < 2) $ do
+        printVersion "depclose"
         putStrLn "Usage: depclose metadata.db RPM [RPM ...]"
         exitFailure
 

--- a/importer/tools/export.hs
+++ b/importer/tools/export.hs
@@ -53,6 +53,7 @@ import qualified BDCS.CS as CS
 import           BDCS.DB
 import           BDCS.Files(groupIdToFiles)
 import           BDCS.Groups(nameToGroupId)
+import           BDCS.Version
 import           Utils.Either(maybeToEither, whenLeft)
 import           Utils.Monad(concatMapM)
 
@@ -189,6 +190,7 @@ expandFileThings = concatMapM isThingFile
 
 usage :: IO ()
 usage = do
+    printVersion "export"
     putStrLn "Usage: export metadata.db repo dest thing [thing ...]"
     putStrLn "dest can be:"
     putStrLn "\t* A directory (which may or may not already exist)"

--- a/importer/tools/import.hs
+++ b/importer/tools/import.hs
@@ -33,6 +33,7 @@ import System.IO(hPutStrLn, stderr)
 
 import qualified BDCS.CS as CS
 import           BDCS.Exceptions(DBException)
+import           BDCS.Version
 import qualified Import.Comps as Comps
 import qualified Import.RPM as RPM
 import qualified Import.Repodata as Repodata
@@ -49,7 +50,8 @@ processThing url = case parseURI url of
 
 usage :: IO ()
 usage = do
-    putStrLn "Usage: test output.db repo thing [thing ...]"
+    printVersion "import"
+    putStrLn "Usage: import output.db repo thing [thing ...]"
     putStrLn "- repo is the path to an already existing content store repo or "
     putStrLn "  the path to a repo to be created"
     putStrLn "- thing can be:"


### PR DESCRIPTION
This shows what git tag and revision it was built from, or uses the
version number from db.cabal