### PR TITLE
Only process one thing per invocation of runSqlite in export.

### DIFF
--- a/importer/tools/export.hs
+++ b/importer/tools/export.hs
@@ -226,10 +226,10 @@ main = do
         whenLeft result print
  where
     processThings :: (MonadError String m, MonadBaseControl IO m, MonadResource m, IsRepo a) => Text -> a -> FilePath -> [Text] -> m ()
-    processThings dbPath repo outPath things = runSqlite dbPath $
-        mapM_ (processOneThingToDir repo outPath) things
+    processThings dbPath repo outPath things =
+        mapM_ (runSqlite dbPath . processOneThingToDir repo outPath) things
 
     processThingsToTar :: (MonadError String m, MonadBaseControl IO m, MonadResource m, IsRepo a) => Text -> a -> FilePath -> [Text] -> m ()
-    processThingsToTar dbPath repo outPath things = runSqlite dbPath $ do
-        entries <- concatMapM (processOneThingToTarEntries repo) things
+    processThingsToTar dbPath repo outPath things = do
+        entries <- concatMapM (runSqlite dbPath . processOneThingToTarEntries repo) things
         liftIO $ writeFile outPath (Tar.write entries)


### PR DESCRIPTION
For some reason, when we start to process the second thing, we get the
following unhelpful error message:

export: SQLite3 returned ErrorMisuse while attempting to perform bind int64.

I can't find any information on where that comes from, and the sqlite
docs just say you are trying to use the library incorrectly.  Whatever.
Reworking the loops so that runSqlite is on the inside fixes things.