### PR TITLE
Travis should run hlint from the importer directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ before_install:
   - cabal update && cabal install hlint hpc-coveralls
 
 script:
-  - ~/.cabal/bin/hlint .
+  - cd importer/ && ~/.cabal/bin/hlint . && cd ../
   - cd haskell-rpm/ && cabal install && cabal clean && cd ../
   - cd importer/ && cabal install --dependencies-only --enable-tests &&
-    cabal configure --enable-tests --enable-coverage --enable-library-coverage &&
+    cabal configure --enable-tests --enable-coverage &&
     cabal build && cabal test --show-details=always
 
 after_script:


### PR DESCRIPTION
Otherwise it doesn't pick up the .hlint.yaml configuration file.

Don't need to run it on haskell-rpm, that is an embedded library and
linting on it should be done upstream.

Also remove --enable-library-coverage to quiet a warning that it is
deprecated and to use --enable-coverage instead.