### PR TITLE
Regenerate the summary after committing to the content store.

### DIFF
--- a/importer/BDCS/CS.hs
+++ b/importer/BDCS/CS.hs
@@ -68,6 +68,7 @@ commit repo repoFile subject body =
         parent <- parentCommit repo "master"
         checksum <- repoWriteCommit repo parent (Just subject) body Nothing root noCancellable
         repoTransactionSetRef repo Nothing "master" (Just checksum)
+        repoRegenerateSummary repo Nothing noCancellable
         return checksum
 
 -- Given an open ostree repo and a checksum to some commit, return a ChecksumMap.  This is useful for


### PR DESCRIPTION
This is necessary for being able to mirror the ostree repo.