### PR TITLE
Allow defining the content store name from the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ d = ${PWD}
 endif
 
 ORG_NAME=weld
+STORE ?= cs.repo
 MDDB ?= metadata.db
 
 weld-f25:
@@ -24,6 +25,8 @@ mddb:
 	docker run -v bdcs-mddb-volume:/mddb -v ${d}/rpms:/rpms:z,ro --security-opt="label:disable" \
 	    --name mddb-container         \
 	    -e "IMPORT_URL=$(IMPORT_URL)" \
+	    -e "KEEP_STORE=$(KEEP_STORE)"   \
+	    -e "STORE=$(STORE)"             \
 	    -e "KEEP_MDDB=$(KEEP_MDDB)"   \
 	    -e "MDDB=$(MDDB)"             \
 	    $(ORG_NAME)/import-img
@@ -56,6 +59,8 @@ import-centos7:
 	for REPO in http://mirror.centos.org/centos/7/os/x86_64 \
 	            http://mirror.centos.org/centos/7/extras/x86_64/; do \
 	    export IMPORT_URL="$$REPO"; \
+	    export KEEP_STORE=1; \
+	    export STORE="centos-store.repo"; \
 	    export KEEP_MDDB=1; \
 	    export MDDB="centos-metadata.db"; \
 	    make mddb; \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+STORE=$(realpath /mddb/${STORE:-cs.repo})
 MDDB="/mddb/${MDDB:-metadata.db}"
+
+if [[ -e "$STORE" && -z "$KEEP_STORE" && "$STORE" =~ ^/mddb/ ]]; then
+    rm -rf "$STORE"
+fi
 
 if [[ -e "$MDDB" && -z "$KEEP_MDDB" ]]; then
     rm "$MDDB"
@@ -11,10 +16,10 @@ if [ ! -f "$MDDB" ]; then
 fi
 
 for f in /rpms/*rpm; do
-    /usr/local/bin/import "$MDDB" cs.repo file://${f}
+    /usr/local/bin/import "$MDDB" "$STORE" file://${f}
 done
 
 # if URL was passed try to import from there
 if [ -n "$IMPORT_URL" ]; then
-    /usr/local/bin/import "$MDDB" cs.repo $IMPORT_URL
+    /usr/local/bin/import "$MDDB" "$STORE" $IMPORT_URL
 fi


### PR DESCRIPTION
Just like with the metadata repo, it may be handy to be able to have
multiple content stores around.  This patch should allow you do that.