### PR TITLE
Use CURDIR in the Makefile instead of PWD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifdef WORKSPACE
 d = ${WORKSPACE}
 else
-d = ${PWD}
+d = ${CURDIR}
 endif
 
 ORG_NAME=weld


### PR DESCRIPTION
The latter environment variable will not be set when sudo is involved,
unless you configure sudo to pass it through.  The former is always set
by make.