### PR TITLE
Copy the content store out of mddb-container before deleting it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ importer:
 	docker build -t $(ORG_NAME)/import-img .
 
 mddb:
+	-rm -rf ./$(MDDB)
+	-rm -rf ./$(STORE)
 	docker volume create -d local --name bdcs-mddb-volume
 	docker rm -f mddb-container || true
 	docker run -v bdcs-mddb-volume:/mddb -v ${d}/rpms:/rpms:z,ro --security-opt="label:disable" \
@@ -31,6 +33,7 @@ mddb:
 	    -e "MDDB=$(MDDB)"             \
 	    $(ORG_NAME)/import-img
 	docker cp mddb-container:/mddb/$(MDDB) ./$(MDDB)
+	docker cp mddb-container:/mddb/$(STORE) ./$(STORE)
 	docker rm mddb-container
 
 api-mddb:


### PR DESCRIPTION
This will result in the complete content store directory structure being
copied out.  If it is to be archived by jenkins, it will need to be
packed up into a tar file (or something similar) but that is handled
elsewhere.