### PR TITLE
Ignore ghost files when exporting to tar.

### DIFF
--- a/importer/tools/export.hs
+++ b/importer/tools/export.hs
@@ -120,7 +120,7 @@ checkoutObjectToTarEntry repo Files{..} =
                             either (\e -> throwError $ "Could not check out object " ++ T.unpack filesPath ++ ": " ++ e)
                                    return
                                    result
-        Nothing       -> throwError $ "Object has no checksum: " ++ T.unpack filesPath
+        Nothing       -> return ()
  where
     checkoutDir :: CS.Metadata -> Either String Tar.Entry
     checkoutDir metadata@CS.Metadata{..} = do


### PR DESCRIPTION
We currently ignore ghost files when exporting to a directory, so do the
same for tar. At some we'll have to actually figure these out.