### PR TITLE
Add a project-level cabal.config file.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 FROM juhp/fedora-haskell-ghc:8.0.2
-RUN dnf -y install xz-devel zlib-devel glib2-devel gobject-introspection-devel ostree-devel && dnf clean all
+RUN dnf -y install xz-devel zlib-devel glib2-devel gobject-introspection-devel ostree-devel sqlite-devel && dnf clean all
 
 ENV PATH ~/.cabal/bin:$PATH
 

--- a/importer/cabal.config
+++ b/importer/cabal.config
@@ -1,0 +1,1 @@
+constraints: persistent-sqlite +systemlib


### PR DESCRIPTION
This should cause persistent-sqlite to be built with the system sqlite
library, insted of the very old copy it includes.  This is enough to do
it in local testing.  Hopefully it is enough to do it when make and
docker are involved.