### PR TITLE
Append slash to repo URIs if not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ import-centos7:
 	mkdir rpms/
 	sqlite3 centos-metadata.db < schema.sql
 	pip install -r tests/requirements.txt
-	for REPO in http://mirror.centos.org/centos/7/os/x86_64 \
+	for REPO in http://mirror.centos.org/centos/7/os/x86_64/ \
 	            http://mirror.centos.org/centos/7/extras/x86_64/; do \
 	    export IMPORT_URL="$$REPO"; \
 	    export KEEP_STORE=1; \


### PR DESCRIPTION
In e18682d we've lost the ability to append slash to base repo URLs if it is not present. Which leads to the following error:
```
./importer/dist/build/import/import metadata.db cs.repo http://mirror.centos.org/centos/7/os/x86_64
import: ParseError {errorContexts = [], errorMessage = "Failed reading: takeWhile1", errorPosition = 1:1}
```

I've fixed the Makefile used by Jenkins and also tried to fix the `loadRepoFromURI` function but for some reason I still get the same error. I'm not sure if we need the same change in `loadFromURI` as well. @dashea any suggestions ?