### PR TITLE
dnf update ostree which will force Jenkins to update its cache

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,6 @@
 FROM juhp/fedora-haskell-ghc:8.0.2
 RUN dnf -y install xz-devel zlib-devel glib2-devel gobject-introspection-devel ostree-devel sqlite-devel && dnf clean all
+RUN dnf -y --enablerepo=updates-testing update ostree-devel && dnf clean all
 
 ENV PATH ~/.cabal/bin:$PATH
 


### PR DESCRIPTION
I'm not sure if we don't need to do the same for weld/f25 image (the runtime which uses import). Jenkins is still compiling. Maybe we'll need to start versioning these docker images to prevent caching issues ?