### PR TITLE
Dockerfile.build should require ostree 2017.8 same as db.cabal

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM juhp/fedora-haskell-ghc:8.0.2
 RUN dnf -y install xz-devel zlib-devel glib2-devel gobject-introspection-devel sqlite-devel \
-                   https://kojipkgs.fedoraproject.org//packages/ostree/2017.6/2.fc25/x86_64/ostree{,-devel,-libs}-2017.6-2.fc25.x86_64.rpm && \
+                   https://kojipkgs.fedoraproject.org/packages/ostree/2017.8/2.fc25/x86_64/ostree{,-devel,-libs}-2017.8-2.fc25.x86_64.rpm && \
     dnf clean all
 
 ENV PATH ~/.cabal/bin:$PATH


### PR DESCRIPTION
Otherwise the importer job fails b/c we can't build the Docker image