### PR TITLE
Treat EXISTING_MDDB as URL to pre-existing metadata.db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,24 @@ import-centos7:
 	make weld-f25
 	make importer
 	mkdir rpms/
-	sqlite3 centos-metadata.db < schema.sql
 	pip install -r tests/requirements.txt
+
+	if [ -n "$$EXISTING_MDDB" ]; then             \
+	    wget "$$EXISTING_MDDB";                   \
+	    gunzip -q `basename "$$EXISTING_MDDB"`;   \
+	    if [ ! -e ${d}/mddb ]; then               \
+	        mkdir ${d}/mddb;                      \
+	    fi;                                       \
+	    UNZIPPED=`basename "$$EXISTING_MDDB" | sed 's/.gz//'`; \
+	    mv $$UNZIPPED ${d}/mddb/$(MDDB);             \
+	fi
+
 	for REPO in http://mirror.centos.org/centos/7/os/x86_64/ \
 	            http://mirror.centos.org/centos/7/extras/x86_64/; do \
 	    export IMPORT_URL="$$REPO"; \
 	    export KEEP_STORE=1; \
 	    export STORE="centos-store.repo"; \
 	    export KEEP_MDDB=1; \
-	    export MDDB="centos-metadata.db"; \
 	    make mddb; \
 	    python ./tests/is_import_busted.py -v $$REPO; \
 	done

--- a/tests/is_import_busted.py
+++ b/tests/is_import_busted.py
@@ -73,7 +73,7 @@ class ImportedDBSanityTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.conn = sqlite3.connect(os.environ.get('MDDB', 'metadata.db'))
+        cls.conn = sqlite3.connect(os.environ.get('MDDB', './mddb/metadata.db'))
         cls.db = cls.conn.cursor()
 
     @classmethod


### PR DESCRIPTION
This is handy during import if we don't want to import all packages from a repo but simply append any new ones that were uploaded in the repository.

NOTE: importer job needs to be updated and pass the EXISTING_MDDB variable to make import-centos. Also it needs to be updated to find the resulting artefacts at mddb/metadata.db