### PR TITLE
Use cache to speed-up build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - ~/.ghc
     - ~/.cabal
+    - ./ostree
 
 addons:
   apt:
@@ -33,10 +34,22 @@ before_install:
   - sudo rm -r /var/lib/dpkg/info/systemd-shim.*
   - sudo apt-get install systemd
   # latest libostree-dev isn't available in Ubuntu yet so build it from source
-  - git clone --recurse-submodules --branch v2017.8 https://github.com/ostreedev/ostree.git && cd ./ostree
-    # temporary fix, https://github.com/ostreedev/ostree/pull/1007
-  - git cherry-pick 47a54bf876023b0cb457bc8a4f4264f9b2ed5438
-  - env NOCONFIGURE=1 ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ../
+  - |
+        # NOTE: When you update libostree version clear the cache from
+        # https://travis-ci.org/weldr/bdcs-api-rs/caches
+        if [ ! -f ./ostree/Makefile ]; then
+            git clone --recurse-submodules --branch v2017.8 https://github.com/ostreedev/ostree.git
+            cd ./ostree
+            # temporary fix, https://github.com/ostreedev/ostree/pull/1007
+            git cherry-pick 47a54bf876023b0cb457bc8a4f4264f9b2ed5438
+            env NOCONFIGURE=1
+            ./autogen.sh
+            ./configure --prefix=/usr
+            make
+        else
+            cd ./ostree
+        fi
+        sudo make install && cd ../
 
   - wget https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 sudo: required
 language: c
 
+cache:
+  directories:
+    - ~/.ghc
+    - ~/.cabal
+
 addons:
   apt:
     sources:
@@ -36,11 +41,11 @@ before_install:
   - wget https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - sudo ./install-haskell-platform.sh
-  - cabal update && cabal install hlint
+  - travis_retry cabal update && cabal install hlint hpc-coveralls
 
 script:
   - cd importer/ && ~/.cabal/bin/hlint . && cd ../
-  - cd importer/ && cabal install --dependencies-only --enable-tests &&
+  - cd importer/ && cabal install --dependencies-only --enable-tests --force-reinstall &&
     cabal configure --enable-tests --enable-coverage &&
     cabal build && cabal test --show-details=always && cabal install
 
@@ -55,7 +60,6 @@ script:
 
 
 after_success:
-  - cabal install hpc-coveralls
   - ~/.cabal/bin/hpc-coveralls --display-report test-db import export
 
 notifications:


### PR DESCRIPTION
Brings the time down from around 35 minutes to about 8 minutes. Other things that take notable time to execute:

- install latest systemd for testing: 20 seconds
- build libostree: 50 seconds
- build the project, test and install it: 100 seconds
- hpc-coveralls: 80 seconds, which seems rather long. It may have something to do with the fact that we're parsing coverage for the binaries as well, not sure. 