### PR TITLE
Ignore errors from missing RSA signatures.

### DIFF
--- a/importer/BDCS/Exceptions.hs
+++ b/importer/BDCS/Exceptions.hs
@@ -14,6 +14,8 @@
 -- License along with this library; if not, see <http://www.gnu.org/licenses/>.
 
 module BDCS.Exceptions(DBException(..),
+                       isDBExceptionException,
+                       isMissingRPMTagException,
                        throwIfNothing,
                        throwIfNothingOtherwise)
  where
@@ -43,3 +45,11 @@ throwIfNothing _        exn = throw exn
 throwIfNothingOtherwise :: Exception e => Maybe a -> e -> (a -> b) -> b
 throwIfNothingOtherwise (Just v) _   fn = fn v
 throwIfNothingOtherwise _        exn _  = throw exn
+
+isDBExceptionException :: DBException -> Bool
+isDBExceptionException (DBException _) = True
+isDBExceptionException _               = False
+
+isMissingRPMTagException :: DBException -> Bool
+isMissingRPMTagException (MissingRPMTag _) = True
+isMissingRPMTagException _                 = False


### PR DESCRIPTION
Unsigned RPMs will not have a RSASignature header. Ignore the error from
this missing header and continue to import the RPM. SHA1 signatures are
still required.