### PR TITLE
Update the name of base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM weld/fedora:25
+FROM welder/fedora:latest
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Related to https://github.com/weldr/welder-deployment/pull/12

We need the image names to match the organization name on docker.com otherwise we can't push.