### PR TITLE
Makefile: make `make importer` grab `export` binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,11 @@ weld-f25:
 	$(MAKE) -C welder-deployment weld-f25
 	-rm -rf ./welder-deployment
 
-importer:
-	docker build -t $(ORG_NAME)/build-img -f Dockerfile.build .
+importer: Dockerfile.build
+	docker build -t $(ORG_NAME)/build-img -f $< .
 	docker create --name build-cont $(ORG_NAME)/build-img
 	docker cp build-cont:/root/.cabal/bin/import ./import
+	docker cp build-cont:/root/.cabal/bin/export ./export
 	docker rm build-cont
 	docker build -t $(ORG_NAME)/import-img .
 


### PR DESCRIPTION
This should make `make importer` copy out the `export` binary in
addition to the `import` binary, so you can play around with the tools
locally if you so desire.

It also makes the `importer` rule depend on Makefile.build, which
doesn't really do anything in this case since `importer` is PHONY and
will rebuild no matter what, but it's kind of best practice to do that
anyway.