### PR TITLE
Save script requirements in a separate context

### DIFF
--- a/importer/BDCS/RPM/Requirements.hs
+++ b/importer/BDCS/RPM/Requirements.hs
@@ -29,6 +29,6 @@ mkGroupRequirement :: Key Groups -> Key Requirements -> GroupRequirements
 mkGroupRequirement groupId reqId =
     GroupRequirements groupId reqId
 
-mkRequirement :: RT.ReqStrength -> T.Text -> Requirements
-mkRequirement strength expr =
-    Requirements RT.RPM RT.Runtime strength expr
+mkRequirement :: RT.ReqContext -> RT.ReqStrength -> T.Text -> Requirements
+mkRequirement context strength expr =
+    Requirements RT.RPM context strength expr

--- a/importer/BDCS/ReqType.hs
+++ b/importer/BDCS/ReqType.hs
@@ -24,7 +24,17 @@ import Database.Persist.TH
 data ReqLanguage = RPM
  deriving(Eq, Read, Show)
 
-data ReqContext = Build | Runtime | Test
+data ReqContext = Build
+                | Runtime
+                | Test
+                | ScriptPre         -- before a package install
+                | ScriptPost        -- after a package install
+                | ScriptPreUn       -- before a package uninstall
+                | ScriptPostUn      -- after a package uninstall
+                | ScriptPreTrans    -- before a package transaction
+                | ScriptPostTrans   -- after a package transaction
+                | ScriptVerify      -- package verification script
+                | Feature           -- feature requirement, e.g. rpmlib features
  deriving(Eq, Read, Show)
 
 data ReqStrength = Must | Should | May | ShouldIfInstalled | MayIfInstalled

--- a/importer/bdcs.cabal
+++ b/importer/bdcs.cabal
@@ -111,6 +111,7 @@ library
                         network-uri,
                         parsec,
                         parsec-numbers,
+                        persistent,
                         persistent-sqlite,
                         persistent-template,
                         process,


### PR DESCRIPTION
Add a bunch of new values to ReqType.ReqContext for requirements that
are needed to install a package but not necessarily needed to run a
package, and parse the RequireFlags tag to assign each requirement to
one or more contexts.