### PR TITLE
Exporter tar image test & .travis.yml fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ after_success:
             sudo docker tag welder/bdcs-build-img:latest welder/bdcs-build-img:$TRAVIS_BUILD_NUMBER
 
             docker login -u atodorov -p $DOCKER_PASSWORD
-            docker push welder/bdcs-api-rs
+            docker push welder/bdcs-build-img
 
             s3cmd sync --access_key="$ARTIFACTS_KEY" --secret_key="$ARTIFACTS_SECRET" -v -P ./import s3://weldr/import
             s3cmd sync --access_key="$ARTIFACTS_KEY" --secret_key="$ARTIFACTS_SECRET" -v -P ./export s3://weldr/export

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ after_success:
   - |
         # copy the coverage data out of the container
         sudo docker cp tests:/importer/dist ./importer/dist
+        # copy compiled binaries out of the container so we can upload
+        # them to S3 later
+        sudo docker cp tests:/importer/dist/import/import .
+        sudo docker cp tests:/importer/dist/export/export .
         sudo docker rm tests
 
         # report to coveralls here because we need access to git

--- a/importer/tests/test_export.sh
+++ b/importer/tests/test_export.sh
@@ -99,6 +99,22 @@ compare_ostree $CS_REPO master $OSTREE_DIR $EXPORT_DIR
 sudo rm -rf $EXPORT_DIR $OSTREE_DIR
 
 ############################################################
+## When exporting existing package into .tar image
+## Then untarred contents match the export from an ostree checkout
+
+sudo $EXPORT $METADATA_DB $CS_REPO exported.tar filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-6.el7.noarch
+if [[ $? != 0 ]]; then
+    echo "ERROR: Exit code should be zero"
+    exit 1
+fi
+
+mkdir tar_contents && pushd tar_contents/ && tar xvf ../exported.tar && popd
+compare_ostree $CS_REPO master $OSTREE_DIR tar_contents/
+
+sudo rm -rf tar_contents/ exported.tar $OSTREE_DIR
+
+
+############################################################
 ## When exporting two conflicting packages
 ## And they conflict on a symlink
 ## Then (since 5834760) the first symlink to be exported wins


### PR DESCRIPTION
Add functional test to verify the contents of exported .tar images

the test will try to extract the tar image inside an empty
directory and then compare that to an ostree checkout like we do
for the other test cases.