### PR TITLE
Exit immediately in case of errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ import-centos7:
 	    ostree --repo=${d}/mddb/$$STORE pull --mirror existing;                 \
 	fi                                                                          \
 
+	set -e
 	for REPO in http://mirror.centos.org/centos/7/os/x86_64/ \
 	            http://mirror.centos.org/centos/7/extras/x86_64/; do \
 	    export IMPORT_URL="$$REPO"; \


### PR DESCRIPTION
- import or tests may be timing out
- tests could fail and we ignore the exit code

this commit will cause the shell to exit immediately if any of the commands fails as is the case with Jenkins job #137.