### PR TITLE
 Label match

### DIFF
--- a/importer/BDCS/Label/Types.hs
+++ b/importer/BDCS/Label/Types.hs
@@ -16,7 +16,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module BDCS.Label.Types(Label(..))
+module BDCS.Label.Types(Label(..),
+                        labelDescriptions)
  where
 
 import           Data.Aeson((.=), ToJSON, object, toJSON)
@@ -38,3 +39,15 @@ instance ToJSON Label where
     toJSON lbl                     = toJSON $ T.pack $ show lbl
 
 derivePersistField "Label"
+
+labelDescriptions :: [(String, String)]
+labelDescriptions = [
+    ("DocsLabel",        "Documentation - mostly things in /usr/share/doc"),
+    ("FontsLabel",       "Fonts"),
+    ("InfoPageLabel",    "GNU info pages"),
+    ("LibraryLabel",     "Static and shared libraries"),
+    ("LicenseLabel",     "Files containing a software license"),
+    ("ManPageLabel",     "man pages"),
+    ("ServiceLabel",     "systemd .service files"),
+    ("TranslationLabel", "Translations - takes a language code as argument")
+ ]

--- a/importer/bdcs.cabal
+++ b/importer/bdcs.cabal
@@ -182,7 +182,8 @@ executable inspect
                         cond,
                         directory,
                         filepath,
-                        process
+                        process,
+                        text
 
     default-language:   Haskell2010
 

--- a/importer/bdcs.cabal
+++ b/importer/bdcs.cabal
@@ -218,7 +218,8 @@ executable inspect-ls
     hs-source-dirs:     tools/inspect/Commands,
                         tools/inspect
 
-    other-modules:      Utils.GetOpt,
+    other-modules:      Utils.Exceptions,
+                        Utils.GetOpt,
                         Utils.IO
 
     build-depends:      aeson,

--- a/importer/tools/inspect/Commands/Ls.hs
+++ b/importer/tools/inspect/Commands/Ls.hs
@@ -5,6 +5,7 @@
 
 import           Control.Conditional(unlessM)
 import           Control.Exception(Handler(..), catches, throw)
+import           Control.Monad(forM_)
 import           Control.Monad.Except(MonadError, runExceptT)
 import           Control.Monad.IO.Class(MonadIO)
 import           Data.Aeson((.=), ToJSON, object, toJSON)
@@ -31,7 +32,7 @@ import qualified BDCS.CS as CS
 import           BDCS.Files(filesC, getKeyValuesForFile)
 import           BDCS.KeyType(KeyType(..))
 import           BDCS.KeyValue(formatKeyValue, keyValueListToJSON)
-import           BDCS.Label.Types(Label)
+import           BDCS.Label.Types(Label, labelDescriptions)
 import           BDCS.Version
 import           Utils.Either(whenLeft)
 import           Utils.Mode(modeAsText)
@@ -245,5 +246,8 @@ main :: IO ()
 main =
     runMain `catches` [Handler (\(InvalidLabelError lbl) -> handleInvalidLabel lbl)]
  where
-     handleInvalidLabel lbl =
-        putStrLn (lbl ++ " is not a recognized file label\n") >> usage
+    handleInvalidLabel lbl = do
+        putStrLn $ lbl ++ " is not a recognized file label\n"
+        putStrLn "Recognized labels:\n"
+        forM_ labelDescriptions $ \(l, d) ->
+            putStrLn $ "      " ++ l ++ " - " ++ d

--- a/importer/tools/inspect/Utils/Exceptions.hs
+++ b/importer/tools/inspect/Utils/Exceptions.hs
@@ -1,9 +1,11 @@
-module Utils.Exceptions(LsErrors(..))
+module Utils.Exceptions(InspectErrors(..))
  where
 
 import Control.Exception(Exception)
 
-data LsErrors = InvalidLabelError String
+data InspectErrors = InvalidLabelError String
+                   | MissingCSError
+                   | MissingDBError
  deriving(Eq, Show)
 
-instance Exception LsErrors
+instance Exception InspectErrors

--- a/importer/tools/inspect/Utils/Exceptions.hs
+++ b/importer/tools/inspect/Utils/Exceptions.hs
@@ -1,0 +1,9 @@
+module Utils.Exceptions(LsErrors(..))
+ where
+
+import Control.Exception(Exception)
+
+data LsErrors = InvalidLabelError String
+ deriving(Eq, Show)
+
+instance Exception LsErrors


### PR DESCRIPTION
Add an ls subcommand option to only print out those files who have a matching file label.  This works with all the various ways of outputting the results.  Also, straighten out a lot of the command line processing and error handling in ls subcommands.  It should be pretty solid now.