### PR TITLE
Update to use the new version of content-store.

### DIFF
--- a/src/Import/RPM.hs
+++ b/src/Import/RPM.hs
@@ -33,7 +33,7 @@ import           Control.Conditional(ifM)
 import           Control.Exception(evaluate, tryJust)
 import           Control.Monad(guard, void)
 import           Control.Monad.Except
-import           Control.Monad.IO.Class(MonadIO, liftIO)
+import           Control.Monad.IO.Class(liftIO)
 import           Control.Monad.Reader(ReaderT, ask)
 import           Control.Monad.Trans(lift)
 import           Control.Monad.Trans.Control(MonadBaseControl)
@@ -75,7 +75,7 @@ import BDCS.Scripts(insertScript)
 import BDCS.RPM.Scripts(mkScripts, mkTriggerScripts)
 #endif
 
-buildImported :: MonadIO m => [Tag] ->  SqlPersistT m Bool
+buildImported :: MonadResource m => [Tag] ->  SqlPersistT m Bool
 buildImported sigs =
     case findStringTag "SHA1Header" sigs of
         Just sha -> do ndx <- select $ from $ \signatures -> do
@@ -126,7 +126,7 @@ unsafeConsume repo db rpm = do
         Left e  -> throwError (CsError $ show e)
         Right v -> return v
  where
-    maybeStore :: (MonadIO m, MonadError CsError m) => Conduit Entry m (Maybe ObjectDigest)
+    maybeStore :: (MonadResource m, MonadError CsError m) => Conduit Entry m (Maybe ObjectDigest)
     maybeStore = awaitForever $ \Entry{..} ->
         -- Only store regular files in the content store
         -- Checking the type is more complicated then you'd think it should be, because
@@ -139,7 +139,7 @@ unsafeConsume repo db rpm = do
 -- Load the headers from a parsed RPM into the mddb.  The return value is whether or not an import
 -- occurred.  This is not the same as success vs. failure, as the import will be skipped if the
 -- package already exists in the mddb.
-loadIntoMDDB :: (MonadBaseControl IO m, MonadIO m, MonadResource m) => RPM -> [(T.Text, Maybe ObjectDigest)] -> SqlPersistT m Bool
+loadIntoMDDB :: (MonadBaseControl IO m, MonadResource m) => RPM -> [(T.Text, Maybe ObjectDigest)] -> SqlPersistT m Bool
 loadIntoMDDB rpm checksums =
     ifM (rpmExistsInMDDB rpm)
         (return False)
@@ -148,7 +148,7 @@ loadIntoMDDB rpm checksums =
 -- Like loadIntoMDDB, but does not first check to see if the RPM has previously been imported.  Running
 -- this could result in a very confused, incorrect mddb.  It is currently for internal use only, but
 -- that might change in the future.
-unsafeLoadIntoMDDB :: (MonadBaseControl IO m, MonadIO m, MonadResource m) => RPM -> [(T.Text, Maybe ObjectDigest)] -> SqlPersistT m Bool
+unsafeLoadIntoMDDB :: (MonadBaseControl IO m, MonadResource m) => RPM -> [(T.Text, Maybe ObjectDigest)] -> SqlPersistT m Bool
 unsafeLoadIntoMDDB RPM{..} checksums = do
     let sigHeaders = headerTags $ head rpmSignatures
     let tagHeaders = headerTags $ head rpmHeaders
@@ -209,7 +209,7 @@ loadFromURI uri = do
 -- Query the MDDB to see if the package has already been imported.  If so, quit now to prevent it
 -- from being added to the content store a second time.  Note that loadIntoMDDB also performs this
 -- check, but both of these functions are public and therefore both need to prevent duplicate imports.
-rpmExistsInMDDB :: MonadIO m => RPM -> SqlPersistT m Bool
+rpmExistsInMDDB :: MonadResource m => RPM -> SqlPersistT m Bool
 rpmExistsInMDDB RPM{..} = do
     let sigHeaders = headerTags $ head rpmSignatures
     buildImported sigHeaders

--- a/src/bdcs.cabal
+++ b/src/bdcs.cabal
@@ -113,7 +113,7 @@ library
                         conduit >= 1.2.8,
                         conduit-combinators,
                         conduit-extra,
-                        content-store >= 0.1.0 && < 0.2.0,
+                        content-store >= 0.2.0 && < 0.3.0,
                         cpio-conduit,
                         cryptonite,
                         directory,
@@ -166,7 +166,7 @@ executable import
     build-depends:      bdcs,
                         base >= 4.7 && < 5.0,
                         cond,
-                        content-store >= 0.1.0 && < 0.2.0,
+                        content-store >= 0.2.0 && < 0.3.0,
                         directory,
                         mtl >= 2.2.1,
                         network-uri
@@ -277,7 +277,7 @@ executable export
                         base >= 4.9 && < 5.0,
                         cond,
                         conduit >= 1.2.8,
-                        content-store >= 0.1.0 && < 0.2.0,
+                        content-store >= 0.2.0 && < 0.3.0,
                         directory,
                         mtl >= 2.2.1,
                         text


### PR DESCRIPTION
On the plus side, this fixes some pretty big bugs that we were bound to
hit at some point.  On the middle side, it means our stores will now be
compressed which might require changes to our testing setup.  On the
minus side, it requires s/MonadIO/MonadResource/ in several places.