### PR TITLE
Don't use ostree checkout when testing exports. Fix #116

### DIFF
--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,7 +1,7 @@
 FROM welder/bdcs-build-img:latest
 MAINTAINER Alexander Todorov <atodorov@redhat.com>
 
-RUN dnf -y install wget && dnf clean all
+RUN dnf -y install wget diffutils && dnf clean all
 
 COPY schema.sql /
 COPY entrypoint-integration-test.sh /usr/local/bin/entrypoint-integration-test.sh

--- a/tests/test_export.sh
+++ b/tests/test_export.sh
@@ -5,25 +5,58 @@ set -x
 
 BDCS="./dist/build/bdcs/bdcs"
 
-function compare_ostree() {
-    # Checks out COMMIT from CS_REPO into OSTREE_DIR and
-    # expects that its contents will match what is in EXPORT_DIR
+function compare_with_rpm() {
+    # Verify that contents of an exported directory have the same files as if
+    # RPMs were installed via rpm.
+    EXPORT_DIR=$1
+    shift
 
-    CS_REPO=$1
-    COMMIT=$2
-    OSTREE_DIR=$3
-    EXPORT_DIR=$4
+    RPMS=$@
+    RPM_CHROOT=`mktemp -d /tmp/rpm-chroot.XXXXXX`
 
-    # Make an ostree checkout to use for comparisons
-    sudo ostree --repo=$CS_REPO checkout $COMMIT $OSTREE_DIR
+    # install the RPMs with rpm
+    sudo rpm -Uhv --root $RPM_CHROOT --nodeps --noscripts $RPMS
     if [[ $? != 0 ]]; then
-        echo "ERROR: ostree exit code should be zero"
+        echo "ERROR: rpm exit code should be zero"
         exit 1
     fi
 
-    for BASE_FILE in `find $OSTREE_DIR -type f`; do
-        echo "... examining $BASE_FILE"
-        EXPECTED_FILE=`echo $BASE_FILE | sed "s|$OSTREE_DIR|$EXPORT_DIR|"`
+    for BASE_FILE in `find $RPM_CHROOT -type f`; do
+        ### skip some files because the rpm -Uhv will produce
+        ### different content for them and cause the test to fail
+
+        if [[ "$BASE_FILE" == */etc/shadow ]]; then
+            echo "INFO: skipping $BASE_FILE ..."
+            continue
+        fi
+
+        if [[ "$BASE_FILE" == */etc/gshadow ]]; then
+            echo "INFO: skipping $BASE_FILE ..."
+            continue
+        fi
+
+        if [[ "$BASE_FILE" == */etc/passwd ]]; then
+            echo "INFO: skipping $BASE_FILE ..."
+            continue
+        fi
+
+        if [[ "$BASE_FILE" == */etc/group ]]; then
+            echo "INFO: skipping $BASE_FILE ..."
+            continue
+        fi
+
+        if [[ "$BASE_FILE" == */var/lib/rpm/* ]]; then
+            echo "INFO: skipping $BASE_FILE ..."
+            continue
+        fi
+
+        if [[ "$BASE_FILE" == *.pyc ]]; then
+            echo "INFO: skipping $BASE_FILE ..."
+            continue
+        fi
+
+        echo "INFO: examining $BASE_FILE ..."
+        EXPECTED_FILE=`echo $BASE_FILE | sed "s|$RPM_CHROOT|$EXPORT_DIR|" | tr -s '/'`
 
         if [[ ! -f "$EXPECTED_FILE" ]]; then
             echo "ERROR: $EXPECTED_FILE doesn't exist"
@@ -35,9 +68,12 @@ function compare_ostree() {
 
         if [[ $BASE_SHA256 != $EXPECTED_SHA256 ]]; then
             echo "ERROR: $BASE_SHA256($BASE_FILE) != $EXPECTED_SHA256($EXPECTED_FILE)"
+            diff -u $BASE_FILE $EXPECTED_FILE
             exit 1
         fi
     done
+
+    sudo rm -rf $RPM_CHROOT
 }
 
 
@@ -52,14 +88,15 @@ fi
 CS_REPO="./export.repo"
 METADATA_DB="./export_metadata.db"
 EXPORT_DIR="./exported-content.d/"
-OSTREE_DIR="./ostree-content.d/"
 
 sqlite3 $METADATA_DB < ../schema.sql
 
 # filesystem package is required by the exporter
-$BDCS import $METADATA_DB $CS_REPO http://mirror.centos.org/centos/7/os/x86_64/Packages/filesystem-3.2-21.el7.x86_64.rpm
+wget http://mirror.centos.org/centos/7/os/x86_64/Packages/filesystem-3.2-21.el7.x86_64.rpm && \
+    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/filesystem-3.2-21.el7.x86_64.rpm
 # setup package is required since 5834760
-$BDCS import $METADATA_DB $CS_REPO http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm
+wget http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm && \
+    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm
 
 ############################################################
 ## When exporting a non-existing package
@@ -80,12 +117,10 @@ sudo rm -rf $EXPORT_DIR
 
 ############################################################
 ## When exporting existing package
-## Then exported contents match the export from an ostree checkout
+## Then exported contents match what's inside the RPM package
 
-
-# import last so we don't have to parse the commit log to figure out what "HEAD" is
-$BDCS import $METADATA_DB $CS_REPO http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
-
+wget http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm && \
+    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
 
 sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch
 if [[ $? != 0 ]]; then
@@ -93,13 +128,12 @@ if [[ $? != 0 ]]; then
     exit 1
 fi
 
-compare_ostree $CS_REPO master $OSTREE_DIR $EXPORT_DIR
-
-sudo rm -rf $EXPORT_DIR $OSTREE_DIR
+compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
+sudo rm -rf $EXPORT_DIR
 
 ############################################################
 ## When exporting existing package into .tar image
-## Then untarred contents match the export from an ostree checkout
+## Then untarred contents match the contents of RPM
 
 sudo $BDCS export $METADATA_DB $CS_REPO exported.tar filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch
 if [[ $? != 0 ]]; then
@@ -108,9 +142,8 @@ if [[ $? != 0 ]]; then
 fi
 
 mkdir tar_contents && pushd tar_contents/ && tar xvf ../exported.tar && popd
-compare_ostree $CS_REPO master $OSTREE_DIR tar_contents/
-
-sudo rm -rf tar_contents/ exported.tar $OSTREE_DIR
+compare_with_rpm tar_contents/ filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
+sudo rm -rf tar_contents/ exported.tar
 
 
 ############################################################
@@ -129,8 +162,10 @@ sudo rm -rf tar_contents/ exported.tar $OSTREE_DIR
 
 # these two packages both provide /usr/lib64/libcmpiCppImpl.so
 # normally libcmpiCppImpl0 lives in the @conflicts group
-$BDCS import $METADATA_DB $CS_REPO http://mirror.centos.org/centos/7/os/x86_64/Packages/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
-$BDCS import $METADATA_DB $CS_REPO http://mirror.centos.org/centos/7/os/x86_64/Packages/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
+wget http://mirror.centos.org/centos/7/os/x86_64/Packages/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm && \
+    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
+wget http://mirror.centos.org/centos/7/os/x86_64/Packages/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm && \
+    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
 
 
 # first libcmpiCppImpl0, second tog-pegasus-libs
@@ -141,10 +176,9 @@ if [[ $? != 0 ]]; then
 fi
 
 # conflict is in tog-pegasus-libs which is the second package in the list
-# make sure libcmpiCppImpl0 wins (master)
-compare_ostree $CS_REPO master $OSTREE_DIR $EXPORT_DIR
-
-sudo rm -rf $EXPORT_DIR $OSTREE_DIR
+# make sure libcmpiCppImpl0 wins
+compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
+sudo rm -rf $EXPORT_DIR
 
 
 # first tog-pegasus-libs, second libcmpiCppImpl0
@@ -155,8 +189,6 @@ if [[ $? != 0 ]]; then
 fi
 
 # conflict is in libcmpiCppImpl0 which is the second package in the list
-# make sure tog-pegasus wins (HEAD~1)
-COMMIT=`ostree --repo=$CS_REPO log master | grep 'commit ' | head -n 2 | tail -n 1 | sed 's/commit //'`
-compare_ostree $CS_REPO $COMMIT $OSTREE_DIR $EXPORT_DIR
-
-sudo rm -rf $EXPORT_DIR $OSTREE_DIR
+# make sure tog-pegasus wins
+compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
+sudo rm -rf $EXPORT_DIR

--- a/tests/test_import.sh
+++ b/tests/test_import.sh
@@ -16,7 +16,7 @@ CENTOS_REPO="centos.repo"
 
 ### test that we can import a single RPM from local disk
 wget http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm && \
-    $IMPORT $METADATA_DB $CENTOS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm
+    $BDCS import $METADATA_DB $CENTOS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm
 if [ $? -ne 0 ]; then
     echo "ERROR: importing from local disk failed"
     exit 1


### PR DESCRIPTION
since 29c5a11 we're using a new version of content-store which, as @clumens confirms, is not a valid ostree repo anymore! So modify the tests to not use ostree checkout anymore.

Instead I use
```
    rpm -Uhv --root ... --nodeps --noscripts *.rpm
```
to install the RPMs into a directory and compare this directory with the results of the export command!