### PR TITLE
Fix the groupIdToNevra string

### DIFF
--- a/src/BDCS/Groups.hs
+++ b/src/BDCS/Groups.hs
@@ -38,7 +38,7 @@ import           Control.Monad.Trans.Resource(MonadResource)
 import           Data.Bifunctor(bimap)
 import           Data.Conduit((.|), Conduit, Source)
 import qualified Data.Conduit.List as CL
-import           Data.Maybe(isNothing, fromJust, fromMaybe)
+import           Data.Maybe(isNothing, fromJust)
 import qualified Data.Text as T
 import           Database.Esqueleto hiding (isNothing)
 
@@ -120,7 +120,11 @@ groupIdToNevra groupId = do
 
     if isNothing n || isNothing v || isNothing r || isNothing a
     then return Nothing
-    else return $ Just $ T.concat [fromMaybe "" e, fromJust n, "-", fromJust v, "-", fromJust r, ".", fromJust a]
+    else return $ Just $ T.concat [fromJust n, "-", epoch e, fromJust v, "-", fromJust r, ".", fromJust a]
+  where
+    epoch :: Maybe T.Text -> T.Text
+    epoch (Just e) = e `T.append` ":"
+    epoch Nothing  = ""
 
 getRequirementsForGroup :: MonadIO m => Key Groups -> RT.ReqContext -> SqlPersistT m [Requirements]
 getRequirementsForGroup groupId context = do

--- a/src/tests/BDCS/GroupsSpec.hs
+++ b/src/tests/BDCS/GroupsSpec.hs
@@ -20,7 +20,7 @@ module BDCS.GroupsSpec(spec)
  where
 
 import BDCS.DB(Groups(..))
-import BDCS.Groups(nevraToGroupId)
+import BDCS.Groups(groupIdToNevra, nevraToGroupId)
 import BDCS.GroupKeyValue(insertGroupKeyValue)
 import BDCS.KeyType(KeyType(..))
 
@@ -63,6 +63,12 @@ spec = describe "BDCS.Groups Tests" $ do
 
     it "nevraToGroupId, wrong arch" $
         withNevras (nevraToGroupId ("hasEpoch", Just "7", "1.0", "1.el7", "i686")) >>= (`shouldBe` Nothing)
+
+    it "groupIdToNevra, has epoch" $
+      withNevras (groupIdToNevra $ toSqlKey 1) >>= (`shouldBe` Just "hasEpoch-7:1.0-1.el7.x86_64")
+
+    it "groupIdToNevra, no epoch" $
+      withNevras (groupIdToNevra $ toSqlKey 2) >>= (`shouldBe` Just "noEpoch-1.0-1.el7.x86_64")
 
  where
     addNevras :: MonadIO m => SqlPersistT m ()


### PR DESCRIPTION
epoch goes before version, separated by a ':', not in front of the
package name.

Also added a test for this.