### PR TITLE
Run cabal commands in the same Docker layer

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -26,7 +26,7 @@ COPY tests/ /bdcs/tests/
 
 WORKDIR /bdcs/
 RUN hlint .
-RUN cabal configure --enable-tests --enable-coverage --prefix=/usr/local
-RUN cabal build
-RUN cabal test --show-details=always
-RUN cabal install --prefix=/usr/local
+RUN cabal configure --enable-tests --enable-coverage --prefix=/usr/local && \
+    cabal build && \
+    cabal test --show-details=always && \
+    cabal install --prefix=/usr/local


### PR DESCRIPTION
this is solving a strange problem for me where cabal test reports missing files in the dist/ directory.

ls: cannot access 'dist/package.conf.inplace/bdcs-0.1.0-KjTA9F29TQcI3Cj7E8Etoz.conf': No such file or directory
ls: cannot access 'dist/package.conf.inplace/package.cache': No such file or directory
total 0
?????????? ? ? ? ?            ? bdcs-0.1.0-KjTA9F29TQcI3Cj7E8Etoz.conf
?????????? ? ? ? ?            ? package.cache