### PR TITLE
Convert shell scripts to beakerlib

### DIFF
--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,7 +1,7 @@
 FROM welder/bdcs-build-img:latest
 MAINTAINER Alexander Todorov <atodorov@redhat.com>
 
-RUN dnf -y install wget diffutils && dnf clean all
+RUN dnf -y install wget diffutils beakerlib
 
 COPY schema.sql /
 COPY entrypoint-integration-test.sh /usr/local/bin/entrypoint-integration-test.sh

--- a/entrypoint-integration-test.sh
+++ b/entrypoint-integration-test.sh
@@ -5,9 +5,16 @@ set -ex
 cd /bdcs/
 
 ./tests/test_tmpfiles.sh
+grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+
 ./tests/test_import.sh
+grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+
 ./tests/test_export.sh
+grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+
 ./tests/test_depsolve.sh
+grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
 
 # collect coverage data from unit tests and binaries
 mkdir ./dist/hpc/vanilla/tix/bdcs-tmpfiles/

--- a/tests/test_depsolve.sh
+++ b/tests/test_depsolve.sh
@@ -1,54 +1,52 @@
 #!/bin/bash
 # Note: execute from the project root directory
 
-set -x
+. /usr/share/beakerlib/beakerlib.sh || exit 1
 
 BDCS="./dist/build/bdcs/bdcs"
-
-# when executed without parameters shows usage
-if [[ `$BDCS depsolve` != "Usage: depsolve metadata.db NEVRA [NEVRA ...]" ]]; then
-    exit 1
-fi
-
-# when executed with non-existing DB returns non-zero
-$BDCS depsolve /tmp/none.db httpd
-if [[ $? == 0 ]]; then
-    echo "FAIL: Return code is zero"
-    exit 1
-fi
-
-### Prepare for testing depsolve against recipes
-
 METADATA_DB="metadata.db"
 CS_REPO="/tmp/depsolve.repo"
-sqlite3 $METADATA_DB < ../schema.sql
 
-DNF_ROOT=`mktemp -d /tmp/dnf.root.XXXXXX`
-DNF_DOWNLOAD=`mktemp -d /tmp/dnf.download.XXXXXX`
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "sqlite3 $METADATA_DB < ../schema.sql"
+        DNF_ROOT=`mktemp -d /tmp/dnf.root.XXXXXX`
+        DNF_DOWNLOAD=`mktemp -d /tmp/dnf.download.XXXXXX`
+    rlPhaseEnd
 
-# first depsolve via dnf and download all the RPMs
-sudo dnf install -y --nogpgcheck --releasever=26 --downloadonly --downloaddir=$DNF_DOWNLOAD --installroot=$DNF_ROOT httpd
+    rlPhaseStartTest "When executed without parameters shows usage"
+        output=`$BDCS depsolve`
+        rlAssertEquals "Usage header is as expected" "$output" "Usage: depsolve metadata.db NEVRA [NEVRA ...]"
+    rlPhaseEnd
 
-# then import all RPMs
-for F in $DNF_DOWNLOAD/*.rpm; do
-    $BDCS import $METADATA_DB $CS_REPO file://$F
-done
+    rlPhaseStartTest "When executed with non-existing DB returns non-zero"
+        $BDCS depsolve /tmp/none.db httpd
+        rlAssertNotEquals "Return code must be non-zero" $? 0
+    rlPhaseEnd
 
-# figure out the exact NEVRA for the httpd package
-HTTPD_NEVRA=`find $DNF_DOWNLOAD -type f -name "httpd-2*.rpm" | cut -f4 -d/ | sed 's/\.rpm//'`
+    rlPhaseStartTest "Depsolve sanity"
+        rlLogInfo "Depsolve and download all the RPMs for httpd via DNF"
+        rlRun "sudo dnf install -y --nogpgcheck --releasever=26 --downloadonly --downloaddir=$DNF_DOWNLOAD --installroot=$DNF_ROOT httpd"
 
+        rlLogInfo "Import all downloaded RPMs"
+        for F in $DNF_DOWNLOAD/*.rpm; do
+            rlRun -c -t "$BDCS import $METADATA_DB $CS_REPO file://$F"
+        done
 
-# when called with correct parameters
-# then output contains input nevra
-# and the return code is 0
-OUTPUT=`$BDCS depsolve $METADATA_DB $HTTPD_NEVRA`
-if [[ $? != 0 ]]; then
-    echo "FAIL: Return code is not zero"
-    exit 1
-fi
+        # figure out the exact NEVRA for the httpd package
+        HTTPD_NEVRA=`find $DNF_DOWNLOAD -type f -name "httpd-2*.rpm" | cut -f4 -d/ | sed 's/\.rpm//'`
 
-echo "$OUTPUT" | grep $HTTPD_NEVRA
-if [ $? != 0 ]; then
-    echo "FAIL: httpd not included in depsolved list"
-    exit 1
-fi
+        # when called with correct parameters
+        # then output contains input nevra
+        # and the return code is 0
+        OUTPUT=`$BDCS depsolve $METADATA_DB $HTTPD_NEVRA`
+        rlAssert0 "depsolve return code must be zero" $?
+
+        echo "$OUTPUT" | grep $HTTPD_NEVRA
+        rlAssert0 "httpd included in depsolved list" $?
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rm -rf $METADATA_DB $CS_REPO $DNF_ROOT $DNF_DOWNLOAD
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/test_export.sh
+++ b/tests/test_export.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Note: execute from the project root directory
 
-set -x
+. /usr/share/beakerlib/beakerlib.sh || exit 1
 
 BDCS="./dist/build/bdcs/bdcs"
+CS_REPO="./export.repo"
+METADATA_DB="./export_metadata.db"
+EXPORT_DIR="./exported-content.d/"
 
 function compare_with_rpm() {
     # Verify that contents of an exported directory have the same files as if
@@ -15,180 +18,131 @@ function compare_with_rpm() {
     RPM_CHROOT=`mktemp -d /tmp/rpm-chroot.XXXXXX`
 
     # install the RPMs with rpm
-    sudo rpm -Uhv --root $RPM_CHROOT --nodeps --noscripts $RPMS
-    if [[ $? != 0 ]]; then
-        echo "ERROR: rpm exit code should be zero"
-        exit 1
-    fi
+    rlRun "sudo rpm -Uhv --root $RPM_CHROOT --nodeps --noscripts $RPMS"
 
     for BASE_FILE in `find $RPM_CHROOT -type f`; do
         ### skip some files because the rpm -Uhv will produce
         ### different content for them and cause the test to fail
 
         if [[ "$BASE_FILE" == */etc/shadow ]]; then
-            echo "INFO: skipping $BASE_FILE ..."
+            rlLogInfo "skipping $BASE_FILE ..."
             continue
         fi
 
         if [[ "$BASE_FILE" == */etc/gshadow ]]; then
-            echo "INFO: skipping $BASE_FILE ..."
+            rlLogInfo "skipping $BASE_FILE ..."
             continue
         fi
 
         if [[ "$BASE_FILE" == */etc/passwd ]]; then
-            echo "INFO: skipping $BASE_FILE ..."
+            rlLogInfo "skipping $BASE_FILE ..."
             continue
         fi
 
         if [[ "$BASE_FILE" == */etc/group ]]; then
-            echo "INFO: skipping $BASE_FILE ..."
+            rlLogInfo "skipping $BASE_FILE ..."
             continue
         fi
 
         if [[ "$BASE_FILE" == */var/lib/rpm/* ]]; then
-            echo "INFO: skipping $BASE_FILE ..."
+            rlLogInfo "skipping $BASE_FILE ..."
             continue
         fi
 
         if [[ "$BASE_FILE" == *.pyc ]]; then
-            echo "INFO: skipping $BASE_FILE ..."
+            rlLogInfo "skipping $BASE_FILE ..."
             continue
         fi
 
-        echo "INFO: examining $BASE_FILE ..."
-        EXPECTED_FILE=`echo $BASE_FILE | sed "s|$RPM_CHROOT|$EXPORT_DIR|" | tr -s '/'`
+        rlLogInfo "examining $BASE_FILE ..."
 
-        if [[ ! -f "$EXPECTED_FILE" ]]; then
-            echo "ERROR: $EXPECTED_FILE doesn't exist"
-            exit 1
-        fi
+        EXPECTED_FILE=`echo $BASE_FILE | sed "s|$RPM_CHROOT|$EXPORT_DIR|" | tr -s '/'`
+        rlAssertExists "$EXPECTED_FILE"
 
         BASE_SHA256=`sha256sum $BASE_FILE | cut -f1 -d' '`
         EXPECTED_SHA256=`sha256sum $EXPECTED_FILE | cut -f1 -d' '`
 
         if [[ $BASE_SHA256 != $EXPECTED_SHA256 ]]; then
-            echo "ERROR: $BASE_SHA256($BASE_FILE) != $EXPECTED_SHA256($EXPECTED_FILE)"
-            diff -u $BASE_FILE $EXPECTED_FILE
-            exit 1
+            rlLogError "$BASE_SHA256($BASE_FILE) != $EXPECTED_SHA256($EXPECTED_FILE)"
+            rlRun "diff -u $BASE_FILE $EXPECTED_FILE"
+            rlFail
         fi
     done
 
     sudo rm -rf $RPM_CHROOT
 }
 
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "sqlite3 $METADATA_DB < ../schema.sql"
+        # filesystem package is required by the exporter
+        rlRun -t -c "wget http://mirror.centos.org/centos/7/os/x86_64/Packages/filesystem-3.2-21.el7.x86_64.rpm"
+        rlRun "$BDCS import $METADATA_DB $CS_REPO file://`pwd`/filesystem-3.2-21.el7.x86_64.rpm"
 
-# when executed without parameters shows usage
-if [[ `$BDCS export | head -n 2 | tail -n 1` != "Usage: export metadata.db repo dest thing [thing ...]" ]]; then
-    exit 1
-fi
+        # setup package is required since 5834760
+        rlRun -t -c "wget http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm"
+        rlRun "$BDCS import $METADATA_DB $CS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm"
 
-############################################################
-### Prepare for testing export functionality
+        rlRun -t -c "wget http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm"
+        rlRun "$BDCS import $METADATA_DB $CS_REPO file://`pwd`/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm"
 
-CS_REPO="./export.repo"
-METADATA_DB="./export_metadata.db"
-EXPORT_DIR="./exported-content.d/"
+        # these two packages both provide /usr/lib64/libcmpiCppImpl.so
+        # normally libcmpiCppImpl0 lives in the @conflicts group
+        rlRun -t -c "wget http://mirror.centos.org/centos/7/os/x86_64/Packages/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm"
+        rlRun "$BDCS import $METADATA_DB $CS_REPO file://`pwd`/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm"
+        rlRun -t -c "wget http://mirror.centos.org/centos/7/os/x86_64/Packages/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm"
+        rlRun "$BDCS import $METADATA_DB $CS_REPO file://`pwd`/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm"
+    rlPhaseEnd
 
-sqlite3 $METADATA_DB < ../schema.sql
+    rlPhaseStartTest "when executed without parameters shows usage"
+        OUTPUT=`$BDCS export | head -n 2 | tail -n 1`
+        rlAssertEquals "Usage header as expected" "$OUTPUT" "Usage: export metadata.db repo dest thing [thing ...]"
+    rlPhaseEnd
 
-# filesystem package is required by the exporter
-wget http://mirror.centos.org/centos/7/os/x86_64/Packages/filesystem-3.2-21.el7.x86_64.rpm && \
-    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/filesystem-3.2-21.el7.x86_64.rpm
-# setup package is required since 5834760
-wget http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm && \
-    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm
+    rlPhaseStartTest "When exporting a non-existing package returns an error"
+        OUTPUT=`sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 NON-EXISTING`
+        rlAssertNotEquals "On error exit code should not be zero" $? 0
+        rlAssertEquals "On error output is as expected" "$OUTPUT" '"No such group NON-EXISTING"'
 
-############################################################
-## When exporting a non-existing package
-## Then returns an error
-
-OUTPUT=`sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 NON-EXISTING`
-if [[ $? == 0 ]]; then
-    echo "ERROR: On error exit code should not be zero"
-    exit 1
-fi
-
-if [[ "$OUTPUT" != '"No such group NON-EXISTING"' ]]; then
-    echo "ERROR: Error output doesn't match"
-    exit 1
-fi
-
-sudo rm -rf $EXPORT_DIR
-
-############################################################
-## When exporting existing package
-## Then exported contents match what's inside the RPM package
-
-wget http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm && \
-    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
-
-sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch
-if [[ $? != 0 ]]; then
-    echo "ERROR: Exit code should be zero"
-    exit 1
-fi
-
-compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
-sudo rm -rf $EXPORT_DIR
-
-############################################################
-## When exporting existing package into .tar image
-## Then untarred contents match the contents of RPM
-
-sudo $BDCS export $METADATA_DB $CS_REPO exported.tar filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch
-if [[ $? != 0 ]]; then
-    echo "ERROR: Exit code should be zero"
-    exit 1
-fi
-
-mkdir tar_contents && pushd tar_contents/ && tar xvf ../exported.tar && popd
-compare_with_rpm tar_contents/ filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
-sudo rm -rf tar_contents/ exported.tar
+        sudo rm -rf $EXPORT_DIR
+    rlPhaseEnd
 
 
-############################################################
-## When exporting two conflicting packages
-## And they conflict on a symlink
-## Then (since 5834760) the first symlink to be exported wins
+    rlPhaseStartTest "When exporting existing package exported contents match what's inside the RPM"
+        rlRun "sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch"
+        compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
+        sudo rm -rf $EXPORT_DIR
+    rlPhaseEnd
 
-# in libcmpiCppImpl0:
-# libcmpiCppImpl.so and libcmpiCppImpl.so.0 are symlinks to libcmpiCppImpl.so.0.0.0
+    rlPhaseStartTest "When exporting existing package into .tar image untarred contents match the contents of RPM"
+        rlRun "sudo $BDCS export $METADATA_DB $CS_REPO exported.tar filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch"
 
-# in tog-pegasus-libs:
-# libcmpiCppImpl.so is a symlink to libcmpiCppImpl.so.1
-
-# the conflicting file is the libcmpiCppImpl.so symlink
-
-
-# these two packages both provide /usr/lib64/libcmpiCppImpl.so
-# normally libcmpiCppImpl0 lives in the @conflicts group
-wget http://mirror.centos.org/centos/7/os/x86_64/Packages/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm && \
-    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
-wget http://mirror.centos.org/centos/7/os/x86_64/Packages/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm && \
-    $BDCS import $METADATA_DB $CS_REPO file://`pwd`/libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
+        mkdir tar_contents && pushd tar_contents/ && tar xvf ../exported.tar && popd
+        compare_with_rpm tar_contents/ filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
+        sudo rm -rf tar_contents/ exported.tar
+    rlPhaseEnd
 
 
-# first libcmpiCppImpl0, second tog-pegasus-libs
-sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch libcmpiCppImpl0-2.0.3-5.el7.x86_64 tog-pegasus-libs-2:2.14.1-5.el7.x86_64 2>&1
-if [[ $? != 0 ]]; then
-    echo "ERROR: Exit code should be zero"
-    exit 1
-fi
+    rlPhaseStartTest "When exporting two conflicting packages on a symlink the first symlink to be exported wins"
+        # in libcmpiCppImpl0:
+        # libcmpiCppImpl.so and libcmpiCppImpl.so.0 are symlinks to libcmpiCppImpl.so.0.0.0
 
-# conflict is in tog-pegasus-libs which is the second package in the list
-# make sure libcmpiCppImpl0 wins
-compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
-sudo rm -rf $EXPORT_DIR
+        # in tog-pegasus-libs:
+        # libcmpiCppImpl.so is a symlink to libcmpiCppImpl.so.1
 
+        # first libcmpiCppImpl0, second tog-pegasus-libs
+        rlRun "$BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch libcmpiCppImpl0-2.0.3-5.el7.x86_64 tog-pegasus-libs-2:2.14.1-5.el7.x86_64 2>&1"
+        # conflict is in tog-pegasus-libs which is the second package in the list
+        # make sure libcmpiCppImpl0 wins
+        compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
+        sudo rm -rf $EXPORT_DIR
 
-# first tog-pegasus-libs, second libcmpiCppImpl0
-sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch tog-pegasus-libs-2:2.14.1-5.el7.x86_64 libcmpiCppImpl0-2.0.3-5.el7.x86_64
-if [[ $? != 0 ]]; then
-    echo "ERROR: Exit code should be zero"
-    exit 1
-fi
+        # first tog-pegasus-libs, second libcmpiCppImpl0
+        rlRun "sudo $BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch tog-pegasus-libs-2:2.14.1-5.el7.x86_64 libcmpiCppImpl0-2.0.3-5.el7.x86_64"
 
-# conflict is in libcmpiCppImpl0 which is the second package in the list
-# make sure tog-pegasus wins
-compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
-sudo rm -rf $EXPORT_DIR
+        # conflict is in libcmpiCppImpl0 which is the second package in the list
+        # make sure tog-pegasus wins
+        compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
+        sudo rm -rf $EXPORT_DIR
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/test_import.sh
+++ b/tests/test_import.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 # Note: execute from the project root directory
 
-set -x
+. /usr/share/beakerlib/beakerlib.sh || exit 1
 
 BDCS="./dist/build/bdcs/bdcs"
-
-# when executed without parameters shows usage
-if [[ `$BDCS import | head -n 2 | tail -n 1` != "Usage: import output.db repo thing [thing ...]" ]]; then
-    exit 1
-fi
-
 METADATA_DB="./import_metadata.db"
-sqlite3 $METADATA_DB < ../schema.sql
 CENTOS_REPO="centos.repo"
 
-### test that we can import a single RPM from local disk
-wget http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm && \
-    $BDCS import $METADATA_DB $CENTOS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm
-if [ $? -ne 0 ]; then
-    echo "ERROR: importing from local disk failed"
-    exit 1
-fi
 
-### test that we can import a single RPM from HTTPS URL
-$BDCS import $METADATA_DB $CENTOS_REPO https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/a/abc-1.01-9.hg20160905.el7.x86_64.rpm
-if [ $? -ne 0 ]; then
-    echo "ERROR: importing from HTTPS URL failed"
-    exit 1
-fi
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "sqlite3 $METADATA_DB < ../schema.sql"
+    rlPhaseEnd
 
-### test that we can import entire repository from HTTPS URL
-$BDCS import $METADATA_DB $CENTOS_REPO https://s3.amazonaws.com/weldr/https-import-repo/
-if [ $? -ne 0 ]; then
-    echo "ERROR: importing from HTTPS REPO failed"
-    exit 1
-fi
+    rlPhaseStartTest "When executed without parameters shows usage"
+        output=`$BDCS import | head -n 2 | tail -n 1`
+        rlAssertEquals "Usage header as expected" "$output" "Usage: import output.db repo thing [thing ...]"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Can import a single RPM from local disk"
+        rlRun -t -c "wget http://mirror.centos.org/centos/7/os/x86_64/Packages/setup-2.8.71-7.el7.noarch.rpm"
+        rlRun -t -c "$BDCS import $METADATA_DB $CENTOS_REPO file://`pwd`/setup-2.8.71-7.el7.noarch.rpm"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Can import a single RPM from HTTPS URL"
+        rlRun -t -c "$BDCS import $METADATA_DB $CENTOS_REPO https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/a/abc-1.01-9.hg20160905.el7.x86_64.rpm"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Can import entire repository from HTTPS URL"
+        rlRun -t -c "$BDCS import $METADATA_DB $CENTOS_REPO https://s3.amazonaws.com/weldr/https-import-repo/"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rm -rf $CENTOS_REPO $METADATA_DB *.rpm
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/test_tmpfiles.sh
+++ b/tests/test_tmpfiles.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 # Note: execute from the project root directory
 
-set -x
+. /usr/share/beakerlib/beakerlib.sh || exit 1
 
 CMD="./dist/build/bdcs-tmpfiles/bdcs-tmpfiles"
 CFG="./data/tmpfiles-default.conf"
 TMPDIR="./test-tmpfiles-$$"
 
-err_cleanup() {
-    rm -rf "$TMPDIR"
-    exit 1
-}
+rlJournalStart
+    rlPhaseStartTest
+        rlRun -t -c "$CMD $CFG $TMPDIR"
 
-$CMD $CFG $TMPDIR || err_cleanup
+        rlAssertExists "$TMPDIR"
+        rlAssertExists "$TMPDIR/var/run"
+        rlAssertExists "$TMPDIR/usr/lib/debug/usr/lib64"
+    rlPhaseEnd
 
-[ -d "$TMPDIR" ] || err_cleanup
-[ -e "$TMPDIR/var/run" ] || err_cleanup
-[ -d "$TMPDIR/usr/lib/debug/usr/lib64" ] || err_cleanup
-
-rm -rf "$TMPDIR"
+    rlPhaseStartCleanup
+        rm -rf $TMPDIR
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
helps us write cleaner and more structured tests

NOTE: there's a simple test result parser in entrypoint-integration-test.sh so we can exit with non-zero in
case of errors.