### PR TITLE
Remove partial functions

### DIFF
--- a/src/BDCS/Build/NPM.hs
+++ b/src/BDCS/Build/NPM.hs
@@ -28,6 +28,7 @@ import           Control.Monad.Trans.Resource(MonadBaseControl, MonadResource)
 import           Data.Bifunctor(bimap)
 import           Data.Bits((.|.))
 import           Data.Conduit(sourceToList)
+import           Data.List(scanl')
 import qualified Data.Text as T
 import           Data.Time.Clock(UTCTime, getCurrentTime)
 import           Data.Time.Clock.POSIX(utcTimeToPOSIXSeconds)
@@ -161,7 +162,7 @@ rebuildNPM sourceId = do
             (link,) <$> insert link
 
         mkdirs :: MonadIO m => UTCTime -> FilePath -> SqlPersistT m [(Files, Key Files)]
-        mkdirs buildTime path = mapM mkdir $ scanl1 (</>) $ splitDirectories path
+        mkdirs buildTime path = mapM mkdir $ scanl' (</>) "/" $ splitDirectories path
          where
             mkdir :: MonadIO m => FilePath -> SqlPersistT m (Files, Key Files)
             mkdir subPath = let

--- a/src/BDCS/Build/NPM.hs
+++ b/src/BDCS/Build/NPM.hs
@@ -116,9 +116,9 @@ rebuildNPM sourceId = do
               limit 1
               return   (projects ^. ProjectsName, sources ^. SourcesVersion)
 
-        when (null nv) $ throwError $ "No such source id " ++ show sourceId
-
-        return $ bimap unValue unValue $ head nv
+        case nv of
+            hd:_ -> return $ bimap unValue unValue hd
+            _    -> throwError $ "No such source id " ++ show sourceId
 
     relink :: (MonadBaseControl IO m, MonadIO m) => [Files] -> (T.Text, T.Text) -> [(T.Text, SemVer)] -> SqlPersistT m (Key Builds)
     relink sourceFiles (name, ver) depList = do

--- a/src/BDCS/DB.hs
+++ b/src/BDCS/DB.hs
@@ -56,8 +56,10 @@ schemaVersion :: Int64
 schemaVersion = 4
 
 -- | Return the version number stored in the database.
-getDbVersion :: MonadIO m => SqlPersistT m Int64
-getDbVersion = unSingle <$> head <$> rawSql "pragma user_version" []
+getDbVersion :: (MonadError String m, MonadIO m) => SqlPersistT m Int64
+getDbVersion = rawSql "pragma user_version" [] >>= \case
+    [] -> throwError "Database does not contain a user_version"
+    v:_ -> return $ unSingle v
 
 -- | Verify that the version number stored in the database matches the schema version number
 -- implemented by this module.  If there is a version mismatch, throw an error.

--- a/src/BDCS/Depclose.hs
+++ b/src/BDCS/Depclose.hs
@@ -168,7 +168,7 @@ depcloseGroupIds arches groupIds = do
                 -- The solution to this requirement is an Or of all the possibilities
                 -- The group ids that are definitely required by this formulas is the intersection of all of the individual sets
                 let reqFormula = Or formulaList
-                let reqParents = foldl1 Set.intersection parentList
+                let reqParents = foldr1 Set.intersection parentList
 
                 -- Add the results to the accumulators
                 return $ Just (reqFormula : formulaAcc, Set.union parentAcc reqParents)

--- a/src/BDCS/Exceptions.hs
+++ b/src/BDCS/Exceptions.hs
@@ -10,6 +10,7 @@
 -- Utilities for working with database-related exceptions.
 
 module BDCS.Exceptions(DBException(..),
+                       isBadNameException,
                        isDBExceptionException,
                        isMissingRPMTagException,
                        throwIfNothing,
@@ -28,11 +29,13 @@ data DBException = DBException String           -- ^ A general purpose exception
                  | MissingRPMTag String         -- ^ A required tag was missing from the
                                                 -- RPM being processed.  The argument should
                                                 -- be the name of the missing tag.
+                 | BadName String               -- ^ The name of the package is not parseable.
  deriving(Eq, Typeable)
 
 instance Exception DBException
 
 instance Show DBException where
+    show (BadName s)       = "Package name is not parseable: " ++ s
     show (DBException s)   = show s
     show (MissingRPMTag s) = "Missing required tag in RPM: " ++ s
 
@@ -47,6 +50,11 @@ throwIfNothing _        exn = throw exn
 throwIfNothingOtherwise :: Exception e => Maybe a -> e -> (a -> b) -> b
 throwIfNothingOtherwise (Just v) _   fn = fn v
 throwIfNothingOtherwise _        exn _  = throw exn
+
+-- | Is a given 'DBException' type a 'BadName'?
+isBadNameException :: DBException -> Bool
+isBadNameException (BadName _) = True
+isBadNameException _           = False
 
 -- | Is a given 'DBException' type the general 'DBException'?
 isDBExceptionException :: DBException -> Bool

--- a/src/BDCS/Export/Ostree.hs
+++ b/src/BDCS/Export/Ostree.hs
@@ -21,7 +21,7 @@ module BDCS.Export.Ostree(ostreeSink)
 import           Conduit(Conduit, Consumer, Producer, (.|), bracketP, runConduit, sourceDirectory, yield)
 import           Control.Conditional(condM, otherwiseM, whenM)
 import           Control.Exception(SomeException, bracket_, catch)
-import           Control.Monad(void, when)
+import           Control.Monad(void)
 import           Control.Monad.Except(MonadError)
 import           Control.Monad.IO.Class(MonadIO, liftIO)
 import           Control.Monad.Trans.Resource(MonadResource, runResourceT)
@@ -192,9 +192,9 @@ ostreeSink outPath = do
 
         -- Find a vmlinuz- file.
         kernelList <- filter ("vmlinuz-" `isPrefixOf`) <$> listDirectory bootDir
-        when (null kernelList) (error "No kernel found")
-        let kernel = bootDir </> head kernelList
-        let kver = drop (length ("vmlinuz-" :: String)) (head kernelList)
+        let (kernel, kver) = case kernelList of
+                                 hd:_ -> (bootDir </> hd, drop (length ("vmlinuz-" :: String)) hd)
+                                 _    -> error "No kernel found"
 
         -- Create the initramfs
         let initramfs = bootDir </> "initramfs-" ++ kver

--- a/src/BDCS/Export/Ostree.hs
+++ b/src/BDCS/Export/Ostree.hs
@@ -28,7 +28,8 @@ import           Control.Monad.Trans.Resource(MonadResource, runResourceT)
 import           Crypto.Hash(SHA256(..), hashInitWith, hashFinalize, hashUpdate)
 import qualified Data.ByteString as BS (readFile)
 import qualified Data.Conduit.List as CL
-import           Data.List(isPrefixOf)
+import           Data.List(isPrefixOf, stripPrefix)
+import           Data.Maybe(fromJust)
 import qualified Data.Text as T
 import           System.Directory
 import           System.FilePath((</>), takeDirectory, takeFileName)
@@ -193,7 +194,9 @@ ostreeSink outPath = do
         -- Find a vmlinuz- file.
         kernelList <- filter ("vmlinuz-" `isPrefixOf`) <$> listDirectory bootDir
         let (kernel, kver) = case kernelList of
-                                 hd:_ -> (bootDir </> hd, drop (length ("vmlinuz-" :: String)) hd)
+                                 -- Using fromJust is fine here - we've ensured they all have that
+                                 -- prefix with the filter above.
+                                 hd:_ -> (bootDir </> hd, fromJust $ stripPrefix "vmlinuz-" hd)
                                  _    -> error "No kernel found"
 
         -- Create the initramfs

--- a/src/BDCS/Export/Utils.hs
+++ b/src/BDCS/Export/Utils.hs
@@ -35,10 +35,10 @@ runHacks exportPath = do
     -- set a root password
     -- pre-crypted from "redhat"
     shadowRecs <- map (splitOn ":") <$> lines <$> readFile (exportPath </> "etc" </> "shadow")
-    let newRecs = map (\rec -> if head rec == "root" then
-                                ["root", "$6$3VLMX3dyCGRa.JX3$RpveyimtrKjqcbZNTanUkjauuTRwqAVzRK8GZFkEinbjzklo7Yj9Z6FqXNlyajpgCdsLf4FEQQKH6tTza35xs/"] ++ drop 2 rec
-                               else
-                                rec) shadowRecs
+    let newRecs = map (\rec -> case rec of
+                                   "root":_:rest -> ["root", "$6$3VLMX3dyCGRa.JX3$RpveyimtrKjqcbZNTanUkjauuTRwqAVzRK8GZFkEinbjzklo7Yj9Z6FqXNlyajpgCdsLf4FEQQKH6tTza35xs/"] ++ rest
+                                   _             -> rec)
+                      shadowRecs
     writeFile (exportPath </> "etc" </> "shadow.new") (unlines $ map (intercalate ":") newRecs)
     renameFile (exportPath </> "etc" </> "shadow.new") (exportPath </> "etc" </> "shadow")
 

--- a/src/BDCS/Groups.hs
+++ b/src/BDCS/Groups.hs
@@ -38,9 +38,8 @@ import           Control.Monad.Trans.Resource(MonadResource)
 import           Data.Bifunctor(bimap)
 import           Data.Conduit((.|), Conduit, Source)
 import qualified Data.Conduit.List as CL
-import           Data.Maybe(isNothing, fromJust)
 import qualified Data.Text as T
-import           Database.Esqueleto hiding (isNothing)
+import           Database.Esqueleto
 
 import           BDCS.DB
 import           BDCS.GroupKeyValue(getValueForGroup)
@@ -118,9 +117,9 @@ groupIdToNevra groupId = do
     r <- getValueForGroup groupId (TextKey "release")
     a <- getValueForGroup groupId (TextKey "arch")
 
-    if isNothing n || isNothing v || isNothing r || isNothing a
-    then return Nothing
-    else return $ Just $ T.concat [fromJust n, "-", epoch e, fromJust v, "-", fromJust r, ".", fromJust a]
+    case (n, v, r, a) of
+        (Just n', Just v', Just r', Just a') -> return $ Just $ T.concat [n', "-", epoch e, v', "-", r', ".", a']
+        _                                    -> return Nothing
   where
     epoch :: Maybe T.Text -> T.Text
     epoch (Just e) = e `T.append` ":"

--- a/src/BDCS/Import/Repodata.hs
+++ b/src/BDCS/Import/Repodata.hs
@@ -20,7 +20,7 @@ module BDCS.Import.Repodata(RepoException,
  where
 
 import           Control.Applicative((<|>))
-import           Control.Exception(Exception)
+import           Control.Exception(Exception, throw)
 import           Control.Monad.IO.Class(MonadIO)
 import           Control.Monad.Reader(ReaderT)
 import           Control.Monad.Trans.Resource(MonadBaseControl, MonadThrow)
@@ -119,4 +119,6 @@ loadFromURI metadataURI = do
     mapM_ RPM.loadFromURI locations
  where
     appendOrThrow :: T.Text -> URI
-    appendOrThrow path = appendURI (baseURI metadataURI) (T.unpack path) `throwIfNothing` RepoException
+    appendOrThrow path = case baseURI metadataURI of
+        Nothing  -> throw RepoException
+        Just uri -> appendURI uri (T.unpack path) `throwIfNothing` RepoException

--- a/src/BDCS/Import/URI.hs
+++ b/src/BDCS/Import/URI.hs
@@ -18,7 +18,6 @@ module BDCS.Import.URI(appendURI,
  where
 
 import Data.List(isInfixOf, isSuffixOf)
-import Data.Maybe(fromJust)
 import Network.URI(URI(..), escapeURIString, isUnescapedInURI,
                    parseURIReference, pathSegments, relativeTo, unEscapeString, uriToString)
 
@@ -30,10 +29,10 @@ uriToPath uri = unEscapeString $ uriPath uri
 -- | Go up one directory in the 'URI'.  For instance:
 -- > ghci> let uri = parseURI "file:///path/to/repo/repodata/primary.xml"
 -- > ghci> baseURI (fromJust uri)
--- > file:///path/to/repo/
-baseURI :: URI -> URI
-baseURI uri = let upOne = fromJust $ parseURIReference ".." in
-    relativeTo upOne uri
+-- > Just file:///path/to/repo/
+baseURI :: URI -> Maybe URI
+baseURI uri = let upOne = parseURIReference ".." in
+    fmap (`relativeTo` uri) upOne
 
 -- | Append a path to a 'URI'.
 appendURI :: URI -> String -> Maybe URI

--- a/src/BDCS/KeyValue.hs
+++ b/src/BDCS/KeyValue.hs
@@ -90,7 +90,10 @@ keyValueListToJSON lst = let
     --
     -- On the other hand, we don't do anything to LabelKeys.  This means labels will always end up
     -- in a list named "labels".
-    pairs = map (\(k, v) -> if length v == 1 then k .= head v else k .= v) (Map.toList otherMap) ++
+    pairs = map (\(k, v) -> case v of
+                                [hd] -> k .= hd
+                                _    -> k .= v)
+                (Map.toList otherMap) ++
             map (uncurry (.=)) (Map.toList labelMap)
  in
     [T.pack "keyvals" .= object pairs]

--- a/src/BDCS/RPM/Builds.hs
+++ b/src/BDCS/RPM/Builds.hs
@@ -46,5 +46,5 @@ mkBuild tags sourceId = let
     getBuildTime = findTag "BuildTime" tags >>= \t -> (tagValue t :: Maybe Word32) >>= Just . posixSecondsToUTCTime . realToFrac
 
     getChangelog = case findStringListTag "ChangeLogText" tags of
-                       []  -> Nothing
-                       lst -> Just $ pack $ head lst
+                       hd:_ -> Just $ pack hd
+                       _    -> Nothing

--- a/src/BDCS/RPM/Groups.hs
+++ b/src/BDCS/RPM/Groups.hs
@@ -17,11 +17,11 @@ module BDCS.RPM.Groups(createGroup)
 
 import           Codec.RPM.Tags(Tag, findStringTag, findStringListTag, findTag, findWord32ListTag, tagValue)
 import           Control.Conditional((<&&>), whenM)
-import           Control.Monad(forM_, void, when)
+import           Control.Monad(forM_, when)
 import           Control.Monad.IO.Class(MonadIO)
 import           Control.Monad.State(State, execState, get, modify)
 import           Data.Bits(testBit)
-import           Data.Maybe(fromJust, isJust)
+import           Data.Maybe(isJust)
 import qualified Data.Text as T
 import           Data.Word(Word32)
 import           Database.Persist.Sql(SqlPersistT, insert)
@@ -135,8 +135,7 @@ createGroup fileIds rpm = do
         uncurry insertGroupKeyValue tup Nothing groupId
 
     -- Add the epoch attribute, when it exists.
-    when (isJust epoch) $ void $
-        insertGroupKeyValue (TextKey "epoch") (fromJust epoch) Nothing groupId
+    forM_ epoch $ \e -> insertGroupKeyValue (TextKey "epoch") e Nothing groupId
 
     forM_ [("Provide", "rpm-provide"), ("Conflict", "rpm-conflict"), ("Obsolete", "rpm-obsolete"), ("Order", "rpm-install-after")] $ \tup ->
         uncurry (addPRCO rpm groupId) tup

--- a/src/tools/bdcs-tmpfiles.hs
+++ b/src/tools/bdcs-tmpfiles.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- Copyright (C) 2017 Red Hat, Inc.
 --
 -- This library is free software; you can redistribute it and/or
@@ -13,7 +15,6 @@
 -- You should have received a copy of the GNU Lesser General Public
 -- License along with this library; if not, see <http://www.gnu.org/licenses/>.
 
-import Control.Monad(when)
 import System.Directory(createDirectoryIfMissing)
 import System.Environment(getArgs)
 import System.Exit(exitFailure)
@@ -29,14 +30,8 @@ usage = do
     putStrLn "       dest should be a destination directory."
     exitFailure
 
-{-# ANN main ("HLint: ignore Use head" :: String) #-}
 main :: IO ()
-main = do
-    argv <- getArgs
-
-    when (length argv /= 2) usage
-
-    let cfg = argv !! 0
-    let dir = argv !! 1
-    createDirectoryIfMissing True dir
-    setupFilesystem dir cfg
+main = getArgs >>= \case
+    cfg:dir:_ -> do createDirectoryIfMissing True dir
+                    setupFilesystem dir cfg
+    _         -> usage

--- a/src/tools/bdcs.hs
+++ b/src/tools/bdcs.hs
@@ -15,7 +15,7 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 
-import Control.Monad(forM_, when)
+import Control.Monad(forM_)
 import System.Environment(getArgs)
 import System.Exit(exitFailure)
 
@@ -45,8 +45,6 @@ main :: IO ()
 main = do
     argv <- getArgs
 
-    when (length argv < 1) usage
-    let subcmd = head argv
-        subcmdArgs = tail argv
-
-    runSubcommand "bdcs-" subcmd subcmdArgs knownSubcommands usage
+    case argv of
+        subcmd:subcmdArgs -> runSubcommand "bdcs-" subcmd subcmdArgs knownSubcommands usage
+        _                 -> usage

--- a/src/tools/inspect/inspect.hs
+++ b/src/tools/inspect/inspect.hs
@@ -46,7 +46,7 @@ usage = do
 
 main :: IO ()
 main = commandLineArgs <$> getArgs >>= \case
-    Just (db, repo, subcmd:_:_:args) ->
+    Just (db, repo, subcmd:args) ->
         runSubcommand "inspect-" subcmd ([db, repo] ++ args) knownSubcommands usage
 
     _ -> usage

--- a/src/tools/inspect/inspect.hs
+++ b/src/tools/inspect/inspect.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-import Control.Monad(forM_, when)
+import Control.Monad(forM_)
 import System.Environment(getArgs)
 import System.Exit(exitFailure)
 
@@ -46,12 +46,7 @@ usage = do
 
 main :: IO ()
 main = commandLineArgs <$> getArgs >>= \case
-    Just (db, repo, args) -> do
-        when (null args) usage
+    Just (db, repo, subcmd:_:_:args) ->
+        runSubcommand "inspect-" subcmd ([db, repo] ++ args) knownSubcommands usage
 
-        let subcmd = head args
-            subcmdArgs = [db, repo] ++ tail args
-
-        runSubcommand "inspect-" subcmd subcmdArgs knownSubcommands usage
-
-    _                     -> usage
+    _ -> usage


### PR DESCRIPTION
For the most part, these are functions that fail on empty or infinite lists.  Removing their use (largely through pattern matching) gets rid of a class of bugs.