### PR TITLE
Share ~/.cabal-sandbox dir between host and docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,39 +6,19 @@ services:
 
 cache:
   directories:
-    - ~/.ghc
-    - ~/.cabal
+    - .cabal-sandbox/
+    - ~/.pip
 
 before_install:
   - sudo pip install s3cmd
-  - sudo docker pull welder/bdcs-build-img:latest
-  - wget https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
-  - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
-  - sudo ./install-haskell-platform.sh
-  - travis_retry cabal update && cabal install hpc-coveralls
-
 
 script:
   - sudo make ci
 
-
 after_success:
-  - |
-        # NOTE: will also copy compiled binaries to S3
-        make ci_after_success
-
-        if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-            sudo docker tag welder/bdcs-build-img:latest welder/bdcs-build-img:$TRAVIS_BUILD_NUMBER
-
-            docker login -u atodorov -p $DOCKER_PASSWORD
-            docker push welder/bdcs-build-img
-        fi
+  - make ci_after_success
 
 notifications:
   email:
     on_failure: change
     on_success: never
-
-env:
-    global:
-        secure: "ppLH0NQB9Q4o4yqteWyfkSKCmoDm1puTz3hMiGjtLf7AZrp9M6F3dv3VWIv+ph7vDxuaL/UA5SSgGwLGi/ZeFt/YNda+nk5oyVR7clGxb8SYOK+S/jBiAKH5SHw7QHpMoJnTlNZE1UmJXzHj96XTWv/XCxBEyx1wjvyjeGVaQS8kM5VFCBp3/jPNonssReotCWVd/I+9tyeCb39cxi8P2mjqsSO0njNIn9gtyqLjEafSypw5qrI1fxBfkS35Ir5aXhmP60o/qy+EaUAdnGjA5+PNB4N5M8/RN09nGX0jNia3mx2ZAwPmU7L/vnzRId61pC2fSyO5A619tG4P+53cJDjtgMf8+y72AZY6yyDGhubEBhMbeegCvrdhNmBEjtH/48zOh0qHRSY4zJQzw5oWZGk6AbZUBvUu5n1DKRDBNLw2RRjTTjNk/uMfZlGsYt96zBrkttK5VIRUCgOqw6zeTZDgJPXNogU5t+2TBUnEOlDFxFYxP4gN804oLfcMu+zAg0e2KeS0nODNkfuJp7r4fuFCRIFhLh2L5GSMT7tAAHLX75iuxdLwmUCfokiVFkIOlC+7FZHXmDenuYM8djQpRZx3WZae2Ff+EE5JfORRuGC4VHp5n1sD7M2uvAjMN4oBZMx52gGHwcETaU3+AB2aGyBQ0ltoL5cZC9V1pN3/Dzo="

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM welder/fedora:latest
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-COPY bdcs /usr/local/bin
-COPY bdcs-import /usr/local/libexec/weldr/
-COPY bdcs-export /usr/local/libexec/weldr/
+COPY dist/build/bdcs/bdcs /usr/local/bin
+COPY dist/build/bdcs-import/bdcs-import /usr/local/libexec/weldr/
+COPY dist/build/bdcs-export/bdcs-export /usr/local/libexec/weldr/
 COPY schema.sql /root/schema.sql

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,25 +8,8 @@ RUN dnf -y install cabal-install \
 
 ENV PATH /root/.cabal/bin:$PATH
 
-RUN cabal update
-RUN cabal install happy
-RUN cabal install hlint
-
-RUN mkdir /bdcs
-
-# install the build dependencies first so we can cache this layer
-COPY bdcs.cabal /bdcs/
-RUN cd /bdcs/ && cabal update && cabal install --dependencies-only --enable-tests --force-reinstall
-
-# copy the rest of the code and build the application
-COPY cabal.config LICENSE Setup.hs .hlint.yaml /bdcs/
-COPY data/ /bdcs/data/
-COPY src/ /bdcs/src/
-COPY tests/ /bdcs/tests/
-
+# source is already bind-mounted here
 WORKDIR /bdcs/
-RUN hlint .
-RUN cabal configure --enable-tests --enable-coverage --prefix=/usr/local && \
-    cabal build && \
-    cabal test --show-details=always && \
-    cabal install --prefix=/usr/local
+
+# build the application
+ENTRYPOINT ["make", "hlint", "tests", "install"]

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -4,5 +4,4 @@ MAINTAINER Alexander Todorov <atodorov@redhat.com>
 RUN dnf -y install wget diffutils beakerlib
 
 COPY schema.sql /
-COPY entrypoint-integration-test.sh /usr/local/bin/entrypoint-integration-test.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint-integration-test.sh"]
+ENTRYPOINT ["/bdcs/entrypoint-integration-test.sh"]

--- a/entrypoint-integration-test.sh
+++ b/entrypoint-integration-test.sh
@@ -5,16 +5,16 @@ set -ex
 cd /bdcs/
 
 ./tests/test_tmpfiles.sh
-grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 
 ./tests/test_import.sh
-grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 
 ./tests/test_export.sh
-grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 
 ./tests/test_depsolve.sh
-grep RESULT_STRING=PASS /var/tmp/beakerlib-*/TestResults || exit 1
+grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 
 # collect coverage data from unit tests and binaries
 mkdir ./dist/hpc/vanilla/tix/bdcs-tmpfiles/

--- a/tests/test_depsolve.sh
+++ b/tests/test_depsolve.sh
@@ -7,9 +7,12 @@ BDCS="./dist/build/bdcs/bdcs"
 METADATA_DB="metadata.db"
 CS_REPO="/tmp/depsolve.repo"
 
+export PATH="./dist/build/bdcs-import:./dist/build/bdcs-depsolve:$PATH"
+
+
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "sqlite3 $METADATA_DB < ../schema.sql"
+        rlRun "sqlite3 $METADATA_DB < ./schema.sql"
         DNF_ROOT=`mktemp -d /tmp/dnf.root.XXXXXX`
         DNF_DOWNLOAD=`mktemp -d /tmp/dnf.download.XXXXXX`
     rlPhaseEnd

--- a/tests/test_import.sh
+++ b/tests/test_import.sh
@@ -6,11 +6,11 @@
 BDCS="./dist/build/bdcs/bdcs"
 METADATA_DB="./import_metadata.db"
 CENTOS_REPO="centos.repo"
-
+export PATH="./dist/build/bdcs-import:$PATH"
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "sqlite3 $METADATA_DB < ../schema.sql"
+        rlRun "sqlite3 $METADATA_DB < ./schema.sql"
     rlPhaseEnd
 
     rlPhaseStartTest "When executed without parameters shows usage"


### PR DESCRIPTION
this should speed up the builds and prevent rebuilding of all Haskell dependencies in Travis.

NOTE: tests on my feature branch fail with:
```
:: [ 15:50:42 ] :: [   LOG    ] :: ---------------  OUTPUT END  ---------------
:: [ 15:50:42 ] :: [   FAIL   ] :: Command './dist/build/bdcs/bdcs import metadata.db /tmp/depsolve.repo file:///tmp/dnf.download.B7A9I6/systemd-233-7.fc26.x86_64.rpm' (Expected 0, got 1)
:: [ 15:50:42 ] :: [  BEGIN   ] :: Running './dist/build/bdcs/bdcs import metadata.db /tmp/depsolve.repo file:///tmp/dnf.download.B7A9I6/systemd-libs-233-7.fc26.x86_64.rpm'
STDOUT: subcommand import does not exist
STDOUT: 
STDOUT: bdcs 97f6666
STDOUT: Usage: bdcs subcommand [args ...]
STDOUT: - subcommands:
STDOUT:       depsolve - print a list of all the dependencies of some object
STDOUT:       export - extract objects from the content store and build an image
STDOUT:       import - load packages into the content store
STDOUT:       inspect - inspect the contents of the content store in various ways
```
