### PR TITLE
docker-related changed to bdcs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,3 @@ welder-deployment/
 *.repo/
 *.db
 **.tix
-dist

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,9 @@ hlint: sandbox
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstall
-	cabal configure --enable-tests --enable-coverage
+	cabal configure --enable-tests --enable-coverage --prefix=/usr/local
 	cabal build
 	cabal test
 
 install:
-	cabal install
+	cabal install --prefix=/usr/local

--- a/Makefile
+++ b/Makefile
@@ -60,40 +60,6 @@ api-mddb:
 
 .PHONY: importer mddb api-mddb ci
 
-import-centos7:
-	make weld-f25
-	make importer
-	mkdir rpms/
-
-	if [ ! -e ${d}/mddb ]; then \
-	    mkdir ${d}/mddb;        \
-	fi;                         \
-
-	if [ -n "$$EXISTING_MDDB" ]; then                          \
-	    wget --progress=dot:giga "$$EXISTING_MDDB";            \
-	    gunzip -q `basename "$$EXISTING_MDDB"`;                \
-	    UNZIPPED=`basename "$$EXISTING_MDDB" | sed 's/.gz//'`; \
-	    mv $$UNZIPPED ${d}/mddb/$(MDDB);                       \
-	fi
-
-	if [ -n "$$EXISTING_STORE" ]; then                                          \
-	    STORE=`basename "$$EXISTING_STORE"`;                                    \
-	    ostree --repo=${d}/mddb/$$STORE init --mode=archive;                    \
-	    ostree --repo=${d}/mddb/$$STORE remote add --no-gpg-verify existing "$$EXISTING_STORE"; \
-	    # note: pulls with --depth=0, only the last commit                      \
-	    ostree --repo=${d}/mddb/$$STORE pull --mirror existing;                 \
-	fi                                                                          \
-
-	set -e
-	for REPO in http://mirror.centos.org/centos/7/os/x86_64/ \
-	            http://mirror.centos.org/centos/7/extras/x86_64/; do \
-	    export IMPORT_URL="$$REPO"; \
-	    export KEEP_STORE=1; \
-	    export STORE="$$STORE"; \
-	    export KEEP_MDDB=1; \
-	    make mddb; \
-	done
-
 ci: integration-test
 
 ci_after_success: install_hpc_coveralls

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,10 @@ integration-test: build Dockerfile.integration-test
 # NOTE: The mddb and content store under ./mddb/ will be removed
 #       Unless KEEP_STORE=1 and KEEP_MDDB=1 are set.
 mddb:
-	@if [ ! -e ${d}/mddb ]; then \
-	    mkdir ${d}/mddb; \
-	fi;
 	sudo docker rm -f mddb-container || true
-	sudo docker run -v ${d}/mddb/:/mddb/ -v ${d}/rpms:/rpms:ro --security-opt="label=disable" \
+	sudo docker volume rm bdcs-mddb-volume || true
+	sudo docker volume create -d local --name bdcs-mddb-volume
+	sudo docker run -v bdcs-mddb-volume:/mddb/ -v ${d}/rpms:/rpms:ro --security-opt="label=disable" \
 	    --name mddb-container         \
 	    -e "IMPORT_URL=$(IMPORT_URL)" \
 	    -e "KEEP_STORE=$(KEEP_STORE)"   \

--- a/README.md
+++ b/README.md
@@ -43,12 +43,10 @@ The Makefile lays out the exact steps and can be used to simplify all this -
 just run `make importer mddb`.  If make is unavailable, just copy the steps
 out of there and run them manually.
 
-You will first need a volume to store the mddb in and a volume containing all
-the RPMs.  The Makefile expects that the mddb will be put into $PWD/mddb, and
-that the RPMs are in $PWD/rpms.
+The Makefile expects that the RPMs are in $PWD/rpms.
 
-After completion, the mddb will be in $PWD/mddb/metadata.db and the content
-store will be in $PWD/mddb/cs.repo/
+After completion, the mddb and content store will be in a bdcs-mddb-volume
+docker volume.
 
 Preparing local development environment for Haskell
 ===================================================

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ You will first need a volume to store the mddb in and a volume containing all
 the RPMs.  The Makefile expects that the mddb will be put into $PWD/mddb, and
 that the RPMs are in $PWD/rpms.
 
-After completion, the mddb will be in $PWD/mddb/metadata.db and the ostree
-based content store will be in $PWD/mddb/cs.repo/
+After completion, the mddb will be in $PWD/mddb/metadata.db and the content
+store will be in $PWD/mddb/cs.repo/
 
 Preparing local development environment for Haskell
 ===================================================
@@ -100,60 +100,3 @@ Produce code coverage report
     $ cabal install --enable-tests --enable-coverage
     $ cabal test
     $ firefox ./dist/hpc/vanilla/tix/*/hpc_index.html
-
-OSTree cheat sheet
-==================
-
-After importing RPMs (via the `import` executable) the results are a
-`metadata.db` SQL database and a `cs.repo` directory containing an
-OSTree repository. Here are a few quick examples how to work with `ostree`:
-
-
-To see what references aka "branches" are in the repo:
-
-    ostree --repo=cs.repo/ refs
-    master
-
-
-To see the commit log (use `less` because ostree doesn't paginate like git):
-
-    ostree --repo=cs.repo/ log master
-    commit 816b63ab93a7a866d598c552f212c3a407648096521fde74cc9aa317730da8b1
-    Date:  2017-07-03 16:32:39 +0000
-    
-        Import of zsh-html into the repo
-    
-    commit f3d66bf3b40e269eac7ed62b6d6f7afdeb5059b17e1b8737aec8b52a03ea82c6
-    Date:  2017-07-03 16:32:38 +0000
-    
-        Import of zsh into the repo
-    
-    commit e370924c48e5b759c05d61b1c4960d96366a91e46eb7449a47c5064986029e50
-    Date:  2017-07-03 16:32:35 +0000
-    
-        Import of yum-rhn-plugin into the repo
-
-To find out the latest commit at `master`:
-
-    ostree --repo=cs.repo/ rev-parse master
-    816b63ab93a7a866d598c552f212c3a407648096521fde74cc9aa317730da8b1
-
-To see what files are inside a particular commit:
-
-    ostree --repo=cs.repo/ ls -RC 816b63ab93a7a866d598c552f212c3a407648096521fde74cc9aa317730da8b1
-    d00755 0 0      0 30bdab0c9a4156b26a923831f0e1c6ba6141c0a8e35c61f30e8febffe7f78de0 446a0ef11b7cc167f3b603e585c7eeeeb675faa412d5ec73f62988eb0b6c5488 /
-    d00755 0 0      0 eeae4a3c7450b786b3d9a6958ef2195c99c1867c2040d9153395e13f38b1ca7b 446a0ef11b7cc167f3b603e585c7eeeeb675faa412d5ec73f62988eb0b6c5488 /usr
-    d00755 0 0      0 0e1e668a21df0ef296e0a7287509b9bac8ae2a03bf6849954b3d0ef905b0cd9a 446a0ef11b7cc167f3b603e585c7eeeeb675faa412d5ec73f62988eb0b6c5488 /usr/share
-    d00755 0 0      0 d5c72afb0dc8197bba6249a8cdfcf155eed0e1d8bf3d3bd02a4e53f3d8c42b37 446a0ef11b7cc167f3b603e585c7eeeeb675faa412d5ec73f62988eb0b6c5488 /usr/share/doc
-    d00755 0 0      0 58efea079328274a2845195529729b190b31b06cc16b5f31c2dc1e2f88825563 446a0ef11b7cc167f3b603e585c7eeeeb675faa412d5ec73f62988eb0b6c5488 /usr/share/doc/zsh-html-5.0.2
-    -00644 0 0   1724 6c691ad9ce0f053823e3fe34795d911170bac0f78f9231389c2e9e2e1271f73a /usr/share/doc/zsh-html-5.0.2/Aliasing.html
-    -00644 0 0   1892 835ffd08dba662f47c7eb3164ae76aa5903363c63d3d606268c0ba928b725e6e /usr/share/doc/zsh-html-5.0.2/Alternate-Forms-For-Complex-Commands.html
-    -00644 0 0   1830 59184f18d807a6b9fc963b709ef82dba4d00f536388935aa79b74160fe90cbfe /usr/share/doc/zsh-html-5.0.2/Alternative-Completion.html
-    -00644 0 0   1734 b1bd5813c780a0862843fd3f468021c9358f5852c8a2029cb6857fb64dd2aed1 /usr/share/doc/zsh-html-5.0.2/Arguments.html
-    -00644 0 0  17635 89309b924ef3874172c73bab3c45eab56da0b847d6328dc387e0e1c5b3dfa633 /usr/share/doc/zsh-html-5.0.2/Arithmetic-Evaluation.html
-
-**NOTE:** `-R` means recursive, `-C` displays file checksums
-
-To check out aka export a commit into a filesystem tree:
-
-    sudo ostree --repo=cs.repo/ checkout 816b63ab93a7a866d598c552f212c3a407648096521fde74cc9aa317730da8b1 some.dir/

--- a/src/BDCS/Build/NPM.hs
+++ b/src/BDCS/Build/NPM.hs
@@ -43,6 +43,8 @@ import BDCS.KeyType
 import BDCS.Label.FileLabels(apply)
 import BDCS.NPM.SemVer(SemVer, SemVerRangeSet, parseSemVer, parseSemVerRangeSet, satisfies, toText)
 
+{-# ANN rebuildNPM ("HLint: ignore Use ." :: String) #-}
+
 rebuildNPM :: (MonadBaseControl IO m, MonadIO m, MonadError String m, MonadResource m) => Key Sources -> SqlPersistT m [Key Builds]
 rebuildNPM sourceId = do
     -- get the name and version for this source

--- a/src/BDCS/Builds.hs
+++ b/src/BDCS/Builds.hs
@@ -28,6 +28,8 @@ import BDCS.DB
 import BDCS.KeyType
 import BDCS.KeyValue(findKeyValue, insertKeyValue)
 
+{-# ANN findBuild ("HLint: ignore Use ." :: String) #-}
+
 -- | Find a single build of a software package in the database, returning the database key
 -- for that build if it exists.  All arguments are required and must be matched for this
 -- function to return anything.  Note that conceptually, a build is of some software source

--- a/src/BDCS/Files.hs
+++ b/src/BDCS/Files.hs
@@ -38,6 +38,11 @@ import           Database.Esqueleto
 import BDCS.DB
 import BDCS.Utils.Conduit(awaitWith)
 
+{-# ANN getKeyValuesForFile ("HLint: ignore Use ." :: String) #-}
+{-# ANN groupIdToFiles ("HLint: ignore Use ." :: String) #-}
+{-# ANN sourceIdToFiles ("HLint: ignore Use ." :: String) #-}
+{-# ANN pathToGroupId ("HLint: ignore Use ." :: String) #-}
+
 insertFiles :: MonadIO m => [Files] -> SqlPersistT m [Key Files]
 insertFiles = mapM insert
 

--- a/src/BDCS/GroupKeyValue.hs
+++ b/src/BDCS/GroupKeyValue.hs
@@ -29,6 +29,9 @@ import BDCS.DB
 import BDCS.KeyType
 import BDCS.KeyValue(findKeyValue, insertKeyValue)
 
+{-# ANN getKeyValuesForGroup ("HLint: ignore Use ." :: String) #-}
+{-# ANN getGroupsByKeyVal ("HLint: ignore Use ." :: String) #-}
+
 insertGroupKeyValue :: MonadIO m => KeyType -> T.Text -> Maybe T.Text -> Key Groups -> SqlPersistT m (Key GroupKeyValues)
 insertGroupKeyValue k v e groupId =
     maybeKey (insertKeyValue k (Just v) e >>= \kvId -> insert $ GroupKeyValues groupId kvId)

--- a/src/BDCS/Groups.hs
+++ b/src/BDCS/Groups.hs
@@ -47,6 +47,12 @@ import           BDCS.KeyType
 import qualified BDCS.ReqType as RT
 import           BDCS.RPM.Utils(splitFilename)
 
+{-# ANN findGroupRequirements ("HLint: ignore Use ." :: String) #-}
+{-# ANN findRequires ("HLint: ignore Use ." :: String) #-}
+{-# ANN getRequirementsForGroup ("HLint: ignore Use ." :: String) #-}
+{-# ANN nameToGroupIds ("HLint: ignore Use ." :: String) #-}
+{-# ANN nevraToGroupId ("HLint: ignore Use ." :: String) #-}
+
 findGroupRequirements :: MonadIO m => Key Groups -> Key Requirements -> SqlPersistT m (Maybe (Key GroupRequirements))
 findGroupRequirements groupId reqId = firstKeyResult $
     select $ from $ \r -> do

--- a/src/BDCS/Import/RPM.hs
+++ b/src/BDCS/Import/RPM.hs
@@ -72,6 +72,8 @@ import BDCS.RPM.Scripts(mkScripts, mkTriggerScripts)
 import BDCS.Scripts(insertScript)
 #endif
 
+{-# ANN buildImported ("HLint: ignore Use ." :: String) #-}
+
 buildImported :: MonadResource m => [Tag] ->  SqlPersistT m Bool
 buildImported sigs =
     case findStringTag "SHA1Header" sigs of

--- a/src/BDCS/KeyValue.hs
+++ b/src/BDCS/KeyValue.hs
@@ -34,6 +34,8 @@ import           Database.Esqueleto
 import BDCS.DB
 import BDCS.KeyType
 
+{-# ANN findKeyValue ("HLint: ignore Use ." :: String) #-}
+
 findKeyValue :: MonadIO m => KeyType -> Maybe T.Text -> Maybe T.Text -> SqlPersistT m (Maybe (Key KeyVal))
 findKeyValue k v e = firstKeyResult $
     select $ from $ \kv -> do

--- a/src/BDCS/Packages.hs
+++ b/src/BDCS/Packages.hs
@@ -28,6 +28,9 @@ import BDCS.DB
 import BDCS.KeyValue(insertKeyValue)
 import BDCS.KeyType
 
+{-# ANN filesInPackage ("HLint: ignore Use ." :: String) #-}
+{-# ANN findPackage ("HLint: ignore Use ." :: String) #-}
+
 filesInPackage :: MonadIO m => T.Text -> SqlPersistT m [T.Text]
 filesInPackage name = do
     results <- select $ from $ \(files `InnerJoin` key_val `InnerJoin` file_key_values) -> do

--- a/src/BDCS/Scripts.hs
+++ b/src/BDCS/Scripts.hs
@@ -26,6 +26,8 @@ import           Database.Esqueleto
 
 import BDCS.DB
 
+{-# ANN findScript ("HLint: ignore Use ." :: String) #-}
+
 -- | Find a single script in the database, returning the key for that script if it
 -- exists.  It is possible for multiple very similar scripts to exist in the same
 -- database (or even, scripts with identical bodies but that differ in other ways)

--- a/src/BDCS/Sources.hs
+++ b/src/BDCS/Sources.hs
@@ -27,6 +27,8 @@ import BDCS.DB
 import BDCS.KeyType
 import BDCS.KeyValue(findKeyValue)
 
+{-# ANN findSource ("HLint: ignore Use ." :: String) #-}
+
 -- | Given a version number and a key to a 'Projects' record, find a matching software
 -- source in the database.  If it exists, the database key is returned.
 findSource :: MonadIO m => T.Text -> Key Projects -> SqlPersistT m (Maybe (Key Sources))


### PR DESCRIPTION
Also, remove some outdated Makefile targets and documentation, and apply a lot of hlint suggestions that are only showing up now due to a newer version of hlint being included in a newer docker image.