### PR TITLE
Handle changes in Cabal-2.0

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -13,6 +13,8 @@
 -- You should have received a copy of the GNU Lesser General Public
 -- License along with this library; if not, see <http://www.gnu.org/licenses/>.
 
+{-# LANGUAGE CPP #-}
+
 module Main(main)
  where
 
@@ -25,6 +27,14 @@ import Distribution.Simple.LocalBuildInfo(LocalBuildInfo(..))
 import Distribution.Simple.UserHooks(UserHooks(..))
 import Distribution.Simple.Setup(ConfigFlags, CopyFlags)
 import System.FilePath((</>))
+
+-- Handle the String to UnqualComponentName switch
+#if defined(MIN_VERSION_Cabal) && MIN_VERSION_Cabal(2, 0, 0)
+import Distribution.Types.UnqualComponentName(UnqualComponentName, unUnqualComponentName)
+#else
+type UnqualComponentName = String
+unUnqualComponentName = id
+#endif
 
 main :: IO ()
 main = defaultMainWithHooks $ simpleUserHooks { confHook = bdcsConf,
@@ -55,8 +65,8 @@ bdcsCopy pkg lbi _ flags = do
     let (subPkg, subLbi) = extractSubComponents pkg lbi
     install subPkg subLbi flags
 
-isSubcommand :: String -> Bool
-isSubcommand s = "inspect-" `isPrefixOf` s || "bdcs-" `isPrefixOf` s
+isSubcommand :: UnqualComponentName -> Bool
+isSubcommand n = let s = unUnqualComponentName n in "inspect-" `isPrefixOf` s || "bdcs-" `isPrefixOf` s
 
 extractMainComponents :: PackageDescription -> LocalBuildInfo -> (PackageDescription, LocalBuildInfo)
 extractMainComponents pkg lbi = let

--- a/bdcs.cabal
+++ b/bdcs.cabal
@@ -40,7 +40,7 @@ extra-source-files:     ChangeLog.md,
 
 custom-setup
     setup-depends:      base,
-                        Cabal,
+                        Cabal >= 1.10 && < 2.1,
                         filepath
 
 source-repository       head


### PR DESCRIPTION
This handles a new type used by Cabal for executable names, and adds
backwards compatibility inside a #if.