### PR TITLE
Compile and test bdcs during docker runtime

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM welder/fedora:latest
 
 # workaround for https://github.com/bos/math-functions/issues/52
-RUN dnf -y install cabal-install \
+RUN dnf -y install cabal-install wget diffutils beakerlib \
     https://kojipkgs.fedoraproject.org//packages/ghc-vector-th-unbox/0.2.1.6/1.fc26/x86_64/ghc-vector-th-unbox-0.2.1.6-1.fc26.x86_64.rpm \
     https://kojipkgs.fedoraproject.org//packages/ghc-vector-th-unbox/0.2.1.6/1.fc26/x86_64/ghc-vector-th-unbox-devel-0.2.1.6-1.fc26.x86_64.rpm && \
     dnf clean all
@@ -11,5 +11,6 @@ ENV PATH /root/.cabal/bin:$PATH
 # source is already bind-mounted here
 WORKDIR /bdcs/
 
-# build the application
-ENTRYPOINT ["make", "hlint", "tests", "install"]
+# build the application and execute integration tests
+# when the container is started
+ENTRYPOINT ["/bdcs/entrypoint-integration-test.sh"]

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,7 +1,0 @@
-FROM welder/bdcs-build-img:latest
-MAINTAINER Alexander Todorov <atodorov@redhat.com>
-
-RUN dnf -y install wget diffutils beakerlib
-
-COPY schema.sql /
-ENTRYPOINT ["/bdcs/entrypoint-integration-test.sh"]

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ api-mddb:
 
 ci: build-and-test
 
-ci_after_success: install_hpc_coveralls
+ci_after_success:
 	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs/ \
-	    --env "TRAVIS=$$TRAVIS" --env "TRAVIS_JOB_ID=$$TRAVIS_JOB_ID" --entrypoint /usr/bin/make welder/bdcs coveralls
+	    --env "TRAVIS=$$TRAVIS" --env "TRAVIS_JOB_ID=$$TRAVIS_JOB_ID" --entrypoint /usr/bin/make welder/bdcs-build-img coveralls
 
 	# upload artifacts on which other test activities depend
 	s3cmd sync -v -P ./bdcs/dist/build/bdcs-import/bdcs-import s3://weldr/bdcs-import

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ci_after_success: install_hpc_coveralls
 
 coveralls: sandbox
 	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
-	.cabal-sandbox/bin/hpc-coveralls --display-report test-bdcs bdcs bdcs-import bdcs-inspect inspect-groups inspect-ls inspect-nevras bdcs-export bdcs-tmpfiles bdcs-depsolve
+	.cabal-sandbox/bin/hpc-coveralls --display-report test-bdcs bdcs
 
 sandbox:
 	cabal update

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,12 @@ weld-f25:
 	$(MAKE) -C welder-deployment weld-f25
 	-rm -rf ./welder-deployment
 
-build: Dockerfile.build
+build-and-test: Dockerfile.build
 	sudo docker build -t welder/bdcs-build-img -f $< .
 	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs/ welder/bdcs-build-img
 
-importer: build
+importer: build-and-test
 	sudo docker build -t welder/bdcs-import-img .
-
-integration-test: build Dockerfile.integration-test
-	sudo docker build -t welder/bdcs-integration-test -f Dockerfile.integration-test .
-	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs/ welder/bdcs-integration-test
 
 
 # NOTE: The mddb and content store under ./mddb/ will be removed
@@ -59,7 +55,7 @@ api-mddb:
 
 .PHONY: importer mddb api-mddb ci
 
-ci: integration-test
+ci: build-and-test
 
 ci_after_success: install_hpc_coveralls
 	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs/ \

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstall
 	cabal configure --enable-tests --enable-coverage --prefix=/usr/local
 	cabal build
-	cabal test
+	cabal test --show-details=always
 
 install:
 	cabal install --prefix=/usr/local

--- a/entrypoint-integration-test.sh
+++ b/entrypoint-integration-test.sh
@@ -18,11 +18,5 @@ grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 
 # collect coverage data from unit tests and binaries
-mkdir ./dist/hpc/vanilla/tix/bdcs-tmpfiles/
-mkdir ./dist/hpc/vanilla/tix/bdcs-import/
-mkdir ./dist/hpc/vanilla/tix/bdcs-export/
-mkdir ./dist/hpc/vanilla/tix/bdcs-depsolve/
-mv bdcs-tmpfiles.tix ./dist/hpc/vanilla/tix/bdcs-tmpfiles/
-mv bdcs-import.tix ./dist/hpc/vanilla/tix/bdcs-import/
-mv bdcs-export.tix ./dist/hpc/vanilla/tix/bdcs-export/
-mv bdcs-depsolve.tix ./dist/hpc/vanilla/tix/bdcs-depsolve/
+mkdir ./dist/hpc/vanilla/tix/bdcs/
+mv bdcs.tix ./dist/hpc/vanilla/tix/bdcs/

--- a/entrypoint-integration-test.sh
+++ b/entrypoint-integration-test.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-cd /bdcs/
+# first build the application
+make hlint tests install
 
 ./tests/test_tmpfiles.sh
 grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1

--- a/tests/test_export.sh
+++ b/tests/test_export.sh
@@ -126,26 +126,16 @@ rlJournalStart
     rlPhaseEnd
 
 
-    rlPhaseStartTest "When exporting two conflicting packages on a symlink the first symlink to be exported wins"
+    rlPhaseStartTest "When exporting two conflicting packages bdcs reports error"
         # in libcmpiCppImpl0:
         # libcmpiCppImpl.so and libcmpiCppImpl.so.0 are symlinks to libcmpiCppImpl.so.0.0.0
 
         # in tog-pegasus-libs:
         # libcmpiCppImpl.so is a symlink to libcmpiCppImpl.so.1
+        OUTPUT=`$BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch libcmpiCppImpl0-2.0.3-5.el7.x86_64 tog-pegasus-libs-2:2.14.1-5.el7.x86_64`
+        rlAssertNotEquals "On error exit code should not be zero" $? 0
+        rlAssertEquals "On error output is as expected" "$OUTPUT" '"Unable to resolve path /usr/lib64/libcmpiCppImpl.so, non-directory object exists at /usr/lib64/libcmpiCppImpl.so.0.0.0"'
 
-        # first libcmpiCppImpl0, second tog-pegasus-libs
-        rlRun "$BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch libcmpiCppImpl0-2.0.3-5.el7.x86_64 tog-pegasus-libs-2:2.14.1-5.el7.x86_64 2>&1"
-        # conflict is in tog-pegasus-libs which is the second package in the list
-        # make sure libcmpiCppImpl0 wins
-        compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm libcmpiCppImpl0-2.0.3-5.el7.x86_64.rpm
-        sudo rm -rf $EXPORT_DIR
-
-        # first tog-pegasus-libs, second libcmpiCppImpl0
-        rlRun "$BDCS export $METADATA_DB $CS_REPO $EXPORT_DIR filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch tog-pegasus-libs-2:2.14.1-5.el7.x86_64 libcmpiCppImpl0-2.0.3-5.el7.x86_64"
-
-        # conflict is in libcmpiCppImpl0 which is the second package in the list
-        # make sure tog-pegasus wins
-        compare_with_rpm $EXPORT_DIR filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm tog-pegasus-libs-2.14.1-5.el7.x86_64.rpm
         sudo rm -rf $EXPORT_DIR
     rlPhaseEnd
 

--- a/tests/test_export.sh
+++ b/tests/test_export.sh
@@ -120,7 +120,7 @@ rlJournalStart
     rlPhaseStartTest "When exporting existing package into .tar image untarred contents match the contents of RPM"
         rlRun "$BDCS export $METADATA_DB $CS_REPO exported.tar filesystem-3.2-21.el7.x86_64 setup-2.8.71-7.el7.noarch yum-rhn-plugin-2.0.1-9.el7.noarch"
 
-        mkdir tar_contents && pushd tar_contents/ && tar xvf ../exported.tar && popd
+        mkdir tar_contents && pushd tar_contents/ && tar xf ../exported.tar && popd
         compare_with_rpm tar_contents/ filesystem-3.2-21.el7.x86_64.rpm setup-2.8.71-7.el7.noarch.rpm yum-rhn-plugin-2.0.1-9.el7.noarch.rpm
         sudo rm -rf tar_contents/ exported.tar
     rlPhaseEnd


### PR DESCRIPTION
this commit merges the build+unit test stage with the integration
test stage so that testing will work again.

Because we mount the local directory to the running
docker container all build/test operations must now happen during
runtime (NOTE: -v mounts read-only during docker build). Without
this change the build stage installs bdcs inside a filesystem layer
which is not accessible to the integration-test container and it
fails.