### PR TITLE
Only depsolve over "Must" requirements.

### DIFF
--- a/src/BDCS/Depclose.hs
+++ b/src/BDCS/Depclose.hs
@@ -137,7 +137,7 @@ depcloseGroupIds arches groupIds = do
         -- Now the recursive part. First, grab everything from the requirements table for this group:
         -- TODO maybe do something with strength, context, etc.
 
-        requirements <- getRequirementsForGroup groupId RT.Runtime >>= mapM reqToDep
+        requirements <- getRequirementsForGroup groupId RT.Runtime RT.Must >>= mapM reqToDep
 
         -- Resolve each requirement to a list of group ids. Each group id is a possibility for satisfying
         -- the requirement. An empty list means the requirement cannot be satisfied.

--- a/src/BDCS/Groups.hs
+++ b/src/BDCS/Groups.hs
@@ -131,12 +131,13 @@ groupIdToNevra groupId = do
     epoch (Just e) = e `T.append` ":"
     epoch Nothing  = ""
 
-getRequirementsForGroup :: MonadIO m => Key Groups -> RT.ReqContext -> SqlPersistT m [Requirements]
-getRequirementsForGroup groupId context = do
+getRequirementsForGroup :: MonadIO m => Key Groups -> RT.ReqContext -> RT.ReqStrength -> SqlPersistT m [Requirements]
+getRequirementsForGroup groupId context strength = do
     vals <- select $ from $ \(reqs `InnerJoin` groupreqs) -> do
             on     $ reqs ^. RequirementsId ==. groupreqs ^. GroupRequirementsReq_id
             where_ $ groupreqs ^. GroupRequirementsGroup_id ==. val groupId &&.
-                     reqs ^. RequirementsReq_context ==. val context
+                     reqs ^. RequirementsReq_context ==. val context &&.
+                     reqs ^. RequirementsReq_strength ==. val strength
             return   reqs
     return $ map entityVal vals
 


### PR DESCRIPTION
During depsolve, ignore all data from Enhances, Suggests, Recommends,
and Supplements. All of these weak requirement types are allowed to fail
in one way or another, so by ignoring them and potentially leaving them
out of the final depsolve result, we are still being technically
correct.