### PR TITLE
Convert the export command into a function.

### DIFF
--- a/bdcs.cabal
+++ b/bdcs.cabal
@@ -61,6 +61,7 @@ library
                         BDCS.Depclose,
                         BDCS.Depsolve,
                         BDCS.Exceptions,
+                        BDCS.Export,
                         BDCS.Export.Directory,
                         BDCS.Export.FSTree,
                         BDCS.Export.Qcow2,

--- a/src/BDCS/Export.hs
+++ b/src/BDCS/Export.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- |
+-- Module: BDCS.Export
+-- Copyright: (c) 2017-2018 Red Hat, Inc.
+-- License: LGPL
+--
+-- Maintainer: https://github.com/weldr
+-- Stability: alpha
+-- Portability: portable
+--
+-- Top-level function for exporting objects from the BDCS.
+
+module BDCS.Export(export)
+ where
+
+import           Control.Conditional(cond)
+import           Control.Monad.Except(MonadError, runExceptT)
+import           Control.Monad.IO.Class(MonadIO, liftIO)
+import           Data.Conduit(Consumer, (.|), runConduit, runConduitRes)
+import           Data.Conduit.List as CL
+import           Data.ContentStore(openContentStore, runCsMonad)
+import           Data.List(isSuffixOf)
+import qualified Data.Text as T
+import           System.Directory(removePathForcibly)
+
+import qualified BDCS.CS as CS
+import           BDCS.DB(Files, checkAndRunSqlite)
+import qualified BDCS.Export.Directory as Directory
+import           BDCS.Export.FSTree(filesToTree, fstreeSource)
+import qualified BDCS.Export.Ostree as Ostree
+import qualified BDCS.Export.Qcow2 as Qcow2
+import qualified BDCS.Export.Tar as Tar
+import           BDCS.Export.Utils(runHacks, runTmpfiles)
+import           BDCS.Files(groupIdToFilesC)
+import           BDCS.Groups(getGroupIdC)
+
+export :: FilePath -> FilePath -> FilePath -> [T.Text] -> IO (Either String ())
+export db repo out_path things | kernelMissing out_path things = return $ Left "ERROR: ostree exports need a kernel package included"
+                               | otherwise                     = runCsMonad (openContentStore repo) >>= \case
+    Left e   -> return $ Left $ show e
+    Right cs -> do
+        let (handler, objectSink) = cond [(".tar" `isSuffixOf` out_path,   (removePathForcibly out_path, CS.objectToTarEntry .| Tar.tarSink out_path)),
+                                          (".qcow2" `isSuffixOf` out_path, (removePathForcibly out_path, Qcow2.qcow2Sink out_path)),
+                                          (".repo" `isSuffixOf` out_path,  (removePathForcibly out_path, Ostree.ostreeSink out_path)),
+                                          (otherwise,                      (return (), directoryOutput out_path))]
+
+        result <- runExceptT $ do
+            -- Build the filesystem tree to export
+            fstree <- checkAndRunSqlite (T.pack db) $ runConduit $ CL.sourceList things
+                        .| getGroupIdC
+                        .| groupIdToFilesC
+                        .| filesToTree
+
+            -- Traverse the tree and export the file contents
+            runConduitRes $ fstreeSource fstree .| CS.filesToObjectsC cs .| objectSink
+
+        case result of
+            Left e  -> handler >> return (Left e)
+            Right _ -> return $ Right ()
+ where
+    directoryOutput :: (MonadError String m, MonadIO m) => FilePath -> Consumer (Files, CS.Object) m ()
+    directoryOutput path = do
+        -- Apply tmpfiles.d to the directory first
+        liftIO $ runTmpfiles path
+
+        Directory.directorySink path
+        liftIO $ runHacks path
+
+    kernelMissing :: FilePath -> [T.Text] -> Bool
+    kernelMissing out lst = ".repo" `isSuffixOf` out && not (any ("kernel-" `T.isPrefixOf`) lst)

--- a/src/BDCS/Export/Utils.hs
+++ b/src/BDCS/Export/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- |
 -- Module: BDCS.Export.Utils
 -- Copyright: (c) 2017 Red Hat, Inc.
@@ -10,18 +12,20 @@
 -- Miscellaneous utilities useful in exporting objects.
 
 module BDCS.Export.Utils(runHacks,
-                         runTmpfiles)
+                         runTmpfiles,
+                         supportedOutputs)
  where
 
-import Control.Conditional(whenM)
-import Control.Exception(tryJust)
-import Control.Monad(guard)
-import Data.List(intercalate)
-import Data.List.Split(splitOn)
-import System.Directory(createDirectoryIfMissing, doesFileExist, listDirectory, removePathForcibly, renameFile)
-import System.FilePath((</>))
-import System.IO.Error(isDoesNotExistError)
-import System.Process(callProcess)
+import           Control.Conditional(whenM)
+import           Control.Exception(tryJust)
+import           Control.Monad(guard)
+import           Data.List(intercalate)
+import           Data.List.Split(splitOn)
+import qualified Data.Text as T
+import           System.Directory(createDirectoryIfMissing, doesFileExist, listDirectory, removePathForcibly, renameFile)
+import           System.FilePath((</>))
+import           System.IO.Error(isDoesNotExistError)
+import           System.Process(callProcess)
 
 import BDCS.Export.TmpFiles(setupFilesystem)
 
@@ -74,3 +78,10 @@ runTmpfiles :: FilePath -> IO ()
 runTmpfiles exportPath = do
     configPath <- getDataFileName "tmpfiles-default.conf"
     setupFilesystem exportPath configPath
+
+-- | List the supported output formats.
+-- Note that any time a new output format file is added in BDCS/Export (and thus to
+-- the runCommand block in tools/export.hs), it should also be added here.  There's
+-- not really any better way to accomplish this.
+supportedOutputs :: [T.Text]
+supportedOutputs = ["directory", "ostree", "qcow2", "tar"]

--- a/src/tools/export.hs
+++ b/src/tools/export.hs
@@ -78,10 +78,8 @@ needKernel = do
     putStrLn "ERROR: ostree exports need a kernel package included"
     exitFailure
 
-runCommand :: FilePath -> FilePath -> FilePath -> [String] -> IO ()
-runCommand db repo out_path fileThings = do
-    things <- map T.pack <$> expandFileThings fileThings
-
+runCommand :: FilePath -> FilePath -> FilePath -> [T.Text] -> IO ()
+runCommand db repo out_path things = do
     cs <- runCsMonad (openContentStore repo) >>= \case
         Left e  -> print e >> exitFailure
         Right r -> return r
@@ -119,5 +117,6 @@ runCommand db repo out_path fileThings = do
 
 main :: IO ()
 main = commandLineArgs <$> getArgs >>= \case
-    Just (db, repo, out_path:things) -> runCommand db repo out_path things
+    Just (db, repo, out_path:things) -> do things' <- map T.pack <$> expandFileThings things
+                                           runCommand db repo out_path things'
     _                                -> usage


### PR DESCRIPTION
This is needed to add support for calling it from the compose API calls.  The command is still around, but basically as a wrapper for the function.