### PR TITLE
Export customize

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,14 @@
+## 0.2.2
+
+* Add BDCS.CS.fileToObjectC, which, when used as part of a conduit, fetches
+  the data for a single file from a ContentStore.
+* Add BDCS.Export.Customize, which provides types and functions for modifying
+  the data exported from a ContentStore.
+* Add BDCS.Export.exportAndCustomize, which includes Customization data in an
+  export.
+* Include schema.sql in the data-files.
+* Bug fixes related to FSTree and symlinks.
+
 ## 0.2.1
 
 * Add BDCS.Export.export, which is the bulk of the "bdcs export" command

--- a/bdcs.cabal
+++ b/bdcs.cabal
@@ -1,5 +1,5 @@
 name:                   bdcs
-version:                0.2.1
+version:                0.2.2
 synopsis:               Tools for managing a content store of software packages
 description:            This module provides a library and various tools for managing a content store and
                         metadata database.  These store the contents of software packages that make up a

--- a/bdcs.cabal
+++ b/bdcs.cabal
@@ -57,6 +57,7 @@ library
                         BDCS.Depsolve,
                         BDCS.Exceptions,
                         BDCS.Export,
+                        BDCS.Export.Customize,
                         BDCS.Export.Directory,
                         BDCS.Export.FSTree,
                         BDCS.Export.Qcow2,

--- a/src/BDCS/Export/Customize.hs
+++ b/src/BDCS/Export/Customize.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module BDCS.Export.Customize(CSOverlay,
+                             Customization(..),
+                             addToOverlay,
+                             filesToObjectsC,
+                             runCustomizations)
+ where
+
+import           Control.Monad(foldM)
+import           Control.Monad.Except(MonadError)
+import           Control.Monad.IO.Class(MonadIO)
+import           Crypto.Hash(Digest, hash)
+import           Crypto.Hash.Algorithms(Blake2b_256)
+import           Data.ByteArray(convert)
+import qualified Data.ByteString as BS
+import           Data.Conduit(Conduit, awaitForever, yield)
+import           Data.ContentStore(ContentStore)
+import qualified Data.Map.Strict as Map
+
+import BDCS.CS(Object(..), fileToObjectC)
+import BDCS.DB(Files(..))
+import BDCS.Export.FSTree(FSTree, addFileToTree)
+
+type CSOverlay = Map.Map BS.ByteString Object
+
+-- Just one type of customization for now, more to come later
+{-# ANN module "HLint: ignore Use newtype instead of data" #-}
+data Customization = WriteFile Files (Maybe BS.ByteString)
+ deriving (Eq, Show)
+
+-- Not everything looks good as an operator, hlint
+{-# ANN filesToObjectsC "HLint: ignore Use section" #-}
+filesToObjectsC :: (MonadError String m, MonadIO m) => CSOverlay -> ContentStore -> Conduit Files m (Files, Object)
+filesToObjectsC overlay repo = awaitForever $ \f@Files{..} ->
+    case maybe Nothing (flip Map.lookup overlay) filesCs_object of
+        Nothing  -> fileToObjectC repo f
+        Just obj -> yield (f, obj)
+
+addToOverlay :: MonadError String m => CSOverlay -> FSTree -> Files -> Maybe BS.ByteString -> m (CSOverlay, FSTree)
+addToOverlay overlay tree file content = do
+    -- If the file has content, create a hash of it and add the content to the overlay.
+    -- The digest type doesn't need to match the content store, it just needs to be something we can
+    -- use as a hash key.
+    let (newFile, newOverlay) = case content of
+            Nothing-> (file{filesCs_object = Nothing}, overlay)
+            Just c -> let digest = makeDigest c
+                      in (file{filesCs_object = Just digest}, Map.insert digest (FileObject c) overlay)
+
+    -- Add the metadata to the FSTree
+    newTree <- addFileToTree True tree newFile
+
+    return (newOverlay, newTree)
+ where
+    makeDigest :: BS.ByteString -> BS.ByteString
+    makeDigest input =
+        let digest = hash input :: Digest Blake2b_256
+        in  convert digest
+
+runCustomizations :: (MonadError String m, MonadIO m) => CSOverlay -> ContentStore -> FSTree -> [Customization] -> m (CSOverlay, FSTree)
+runCustomizations overlay _repo tree customizations = foldM runCustomization (overlay, tree) customizations
+ where
+    runCustomization :: MonadError String m => (CSOverlay, FSTree) -> Customization -> m (CSOverlay, FSTree)
+    runCustomization (o, t) (WriteFile file content) = addToOverlay o t file content


### PR DESCRIPTION
This adds the start of a framework for customizing the content of an export with data that is not contained within the mddb or content-store. The idea of this is that it can be used for configuration directives, similar to what is provided by kickstart or cloud-init, and the configuration can be applied at the time of the export.

Currently the only directive is "WriteFile". We're going to want to add file modification at the very least (for setting passwords, for instance), and probably file deletion, but I figured this was a good place to start.

Bumped the bdcs version to 0.2.2 so that bdcs-api can depend on the API changes.