### PR TITLE
Add a new ExportType data type.

### DIFF
--- a/bdcs.cabal
+++ b/bdcs.cabal
@@ -64,6 +64,7 @@ library
                         BDCS.Export.Ostree,
                         BDCS.Export.Tar,
                         BDCS.Export.TmpFiles,
+                        BDCS.Export.Types,
                         BDCS.Export.Utils,
                         BDCS.Files,
                         BDCS.GroupKeyValue,

--- a/src/BDCS/Export/Types.hs
+++ b/src/BDCS/Export/Types.hs
@@ -1,0 +1,43 @@
+-- |
+-- Module: BDCS.Export.Types
+-- Copyright: (c) 2018 Red Hat, Inc.
+-- License: LGPL
+--
+-- Maintainer: https://github.com/weldr
+-- Stability: alpha
+-- Portability: portable
+--
+-- Types related to exporting.
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module BDCS.Export.Types(ExportType(..),
+                         exportTypeText,
+                         exportTypeFromText,
+                         supportedExportTypes)
+ where
+
+import qualified Data.Text as T
+
+data ExportType = ExportDirectory
+                | ExportOstree
+                | ExportQcow2
+                | ExportTar
+ deriving(Eq, Show)
+
+exportTypeText :: ExportType -> T.Text
+exportTypeText ExportDirectory = "directory"
+exportTypeText ExportOstree    = "ostree"
+exportTypeText ExportQcow2     = "qcow2"
+exportTypeText ExportTar       = "tar"
+
+exportTypeFromText :: T.Text -> Maybe ExportType
+exportTypeFromText t = case T.toLower (T.strip t) of
+    "directory" -> Just ExportDirectory
+    "ostree"    -> Just ExportOstree
+    "qcow2"     -> Just ExportQcow2
+    "tar"       -> Just ExportTar
+    _           -> Nothing
+
+supportedExportTypes :: [ExportType]
+supportedExportTypes = [ExportDirectory, ExportOstree, ExportQcow2, ExportTar]

--- a/src/BDCS/Export/Utils.hs
+++ b/src/BDCS/Export/Utils.hs
@@ -12,8 +12,7 @@
 -- Miscellaneous utilities useful in exporting objects.
 
 module BDCS.Export.Utils(runHacks,
-                         runTmpfiles,
-                         supportedOutputs)
+                         runTmpfiles)
  where
 
 import           Control.Conditional(whenM)
@@ -88,10 +87,3 @@ runTmpfiles :: MonadLoggerIO m => FilePath -> m ()
 runTmpfiles exportPath = do
     configPath <- liftIO $ getDataFileName "data/tmpfiles-default.conf"
     setupFilesystem exportPath configPath
-
--- | List the supported output formats.
--- Note that any time a new output format file is added in BDCS/Export (and thus to
--- the runCommand block in tools/export.hs), it should also be added here.  There's
--- not really any better way to accomplish this.
-supportedOutputs :: [T.Text]
-supportedOutputs = ["directory", "ostree", "qcow2", "tar"]

--- a/src/tools/export.hs
+++ b/src/tools/export.hs
@@ -1,4 +1,4 @@
--- Copyright (C) 2017 Red Hat, Inc.
+-- Copyright (C) 2017-2018 Red Hat, Inc.
 --
 -- This library is free software; you can redistribute it and/or
 -- modify it under the terms of the GNU Lesser General Public
@@ -14,22 +14,46 @@
 -- License along with this library; if not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
-import           Control.Conditional(cond, ifM)
+import           Control.Conditional(ifM)
 import           Control.Monad.Except(runExceptT)
-import           Data.List(isSuffixOf)
+import           Data.Maybe(fromJust, isNothing)
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+import           System.Console.GetOpt
 import           System.Directory(doesFileExist, removePathForcibly)
 import           System.Environment(getArgs)
 import           System.Exit(exitFailure, exitSuccess)
 
 import BDCS.DB(checkAndRunSqlite)
 import BDCS.Export(export)
-import BDCS.Export.Types(ExportType(..))
+import BDCS.Export.Types(exportTypeText, exportTypeFromText, supportedExportTypes)
 import BDCS.Utils.Monad(concatMapM)
 import BDCS.Version
 
-import Utils.GetOpt(commandLineArgs)
+import Utils.GetOpt(OptClass, commandLineArgs, compilerOpts)
+
+data ExportOpts = ExportOpts { optDest :: FilePath,
+                               optExportType :: T.Text }
+
+instance OptClass ExportOpts
+
+defaultExportOpts :: ExportOpts
+defaultExportOpts = ExportOpts { optDest = "",
+                                 optExportType = "tar" }
+
+options :: [OptDescr (ExportOpts -> ExportOpts)]
+options = [
+    Option ['d'] ["dest"]
+           (ReqArg (\d opts -> opts { optDest = d }) "DEST")
+           "destination",
+    Option ['t'] ["type"]
+           (ReqArg (\t opts -> opts { optExportType = T.pack t }) "TYPE")
+           "export type"
+ ]
 
 -- | Check a list of strings to see if any of them are files
 -- If it is, read it and insert its contents in its place
@@ -41,32 +65,41 @@ expandFileThings = concatMapM isThingFile
                             (lines <$> readFile thing)
                             (return [thing])
 
+validExportTypes :: T.Text
+validExportTypes = T.intercalate ", " (map exportTypeText supportedExportTypes)
+
 usage :: IO ()
 usage = do
     printVersion "export"
-    putStrLn "Usage: export metadata.db repo dest thing [thing ...]"
-    putStrLn "dest can be:"
-    putStrLn "\t* A directory (which may or may not already exist)"
-    putStrLn "\t* The name of a .tar file to be created"
-    putStrLn "\t* The name of a .qcow2 image to be created"
-    putStrLn "\t* A directory ending in .repo, which will create a new ostree repo"
-    putStrLn "thing can be:"
-    putStrLn "\t* The NEVRA of an RPM, e.g. filesystem-3.2-21.el7.x86_64"
-    putStrLn "\t* A path to a file containing NEVRA of RPMs, 1 per line."
+    putStrLn   "Usage: export metadata.db repo -t [export type] -d [dest] thing [thing ...]"
+    putStrLn   "metadata.db - The path to an existing metadata repo"
+    putStrLn   "repo        - The path to an existing content store"
+    putStrLn $ "export type - One of the supported export types: " ++ T.unpack validExportTypes
+    putStrLn   "dest        - The name of the export artifact to be created"
+    putStrLn   "thing       -"
+    putStrLn   "\t* The NEVRA of an RPM, e.g. filesystem-3.2-21.el7.x86_64"
+    putStrLn   "\t* A path to a file containing NEVRA of RPMs, 1 per line."
     -- TODO group id?
     exitFailure
 
 main :: IO ()
 main = commandLineArgs <$> getArgs >>= \case
-    Just (db, repo, out_path:things) -> do things' <- map T.pack <$> expandFileThings things
+    Nothing               -> usage
+    Just (db, repo, args) -> do
+        (ExportOpts{..}, things) <- compilerOpts options defaultExportOpts args "export"
+        things'                  <- map T.pack <$> expandFileThings things
 
-                                           let ty = cond [(".tar" `isSuffixOf` out_path,   ExportTar),
-                                                          (".qcow2" `isSuffixOf` out_path, ExportQcow2),
-                                                          (".repo" `isSuffixOf` out_path,  ExportOstree),
-                                                          (otherwise,                      ExportDirectory)]
-
-                                           result  <- runExceptT $ checkAndRunSqlite (T.pack db) $ export repo out_path ty things'
-                                           case result of
-                                               Left err -> removePathForcibly out_path >> print err >> exitFailure
-                                               Right _  -> exitSuccess
-    _                                -> usage
+        if | isNothing (exportTypeFromText optExportType) -> do
+                 TIO.putStrLn $ "Invalid export type.  Valid types are: " `T.append` validExportTypes
+                 exitFailure
+           | null optDest -> do
+                 putStrLn "No export destination given."
+                 exitFailure
+           | null things' -> do
+                 putStrLn "Nothing to export."
+                 exitFailure
+           | otherwise -> do
+                 let ty = fromJust $ exportTypeFromText optExportType
+                 runExceptT (checkAndRunSqlite (T.pack db) $ export repo optDest ty things') >>= \case
+                     Left err -> removePathForcibly optDest >> print err >> exitFailure
+                     Right _  -> exitSuccess


### PR DESCRIPTION
This allows breaking apart the tie between the name of the thing to export and the type of the thing being exported.  It also allows for eliminating string comparisons here and in bdcs-api.  Note that this will also require bumping the minor version because I got rid of supportedOutputs.