### PR TITLE
Don't throw an exception in the pure option processing code.

### DIFF
--- a/src/tools/inspect/Utils/Exceptions.hs
+++ b/src/tools/inspect/Utils/Exceptions.hs
@@ -3,7 +3,7 @@ module Utils.Exceptions(InspectErrors(..))
 
 import Control.Exception(Exception)
 
-data InspectErrors = InvalidLabelError String
+data InspectErrors = InvalidLabelError
                    | MissingCSError
                    | MissingDBError
  deriving(Eq, Show)

--- a/src/tools/inspect/subcommands/groups.hs
+++ b/src/tools/inspect/subcommands/groups.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import           Control.Conditional(unlessM)
-import           Control.Exception(Handler(..), catches, throw)
+import           Control.Exception(Handler(..), catches, throwIO)
 import           Control.Monad.Except(runExceptT)
 import           Data.Aeson((.=), ToJSON, object, toJSON)
 import           Data.Aeson.Encode.Pretty(encodePretty)
@@ -117,7 +117,7 @@ runMain = do
         Nothing               -> usage
         Just (db, repo, args) -> do
             unlessM (doesFileExist db) $
-                throw MissingDBError
+                throwIO MissingDBError
 
             result <- runCommand (T.pack db) repo args
             whenLeft result (\e -> print $ "error: " ++ e)

--- a/src/tools/inspect/subcommands/nevras.hs
+++ b/src/tools/inspect/subcommands/nevras.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import           Control.Conditional(unlessM)
-import           Control.Exception(Handler(..), catches, throw)
+import           Control.Exception(Handler(..), catches, throwIO)
 import           Control.Monad.Except(runExceptT)
 import           Data.Conduit((.|), runConduit)
 import qualified Data.Conduit.List as CL
@@ -65,7 +65,7 @@ runMain = do
         Nothing               -> usage
         Just (db, repo, args) -> do
             unlessM (doesFileExist db) $
-                throw MissingDBError
+                throwIO MissingDBError
 
             result <- runCommand (T.pack db) repo args
             whenLeft result (\e -> print $ "error: " ++ e)


### PR DESCRIPTION
Instead, use throwIO afterwards.  This discards the bad label value that
was given, but I think the error message is enough that the user will be
able to tell what they've done wrong and how to fix it.