### PR TITLE
Add logging for the dracut call in Ostree.hs.

### DIFF
--- a/src/BDCS/Export/Ostree.hs
+++ b/src/BDCS/Export/Ostree.hs
@@ -20,7 +20,6 @@ module BDCS.Export.Ostree(ostreeSink)
 
 import           Conduit(Conduit, Consumer, Producer, (.|), bracketP, runConduit, sourceDirectory, yield)
 import           Control.Conditional(condM, otherwiseM, whenM)
-import           Control.Exception(SomeException, bracket_, catch)
 import qualified Control.Exception.Lifted as CEL
 import           Control.Monad(void)
 import           Control.Monad.Except(MonadError)
@@ -325,8 +324,8 @@ open fp = do
 -- Given a commit, return the parent of it or Nothing if no parent exists.
 parentCommit :: IsRepo a => a -> T.Text -> IO (Maybe T.Text)
 parentCommit repo commitSum =
-    catch (Just <$> repoResolveRev repo commitSum False)
-          (\(_ :: SomeException) -> return Nothing)
+    CEL.catch (Just <$> repoResolveRev repo commitSum False)
+              (\(_ :: CEL.SomeException) -> return Nothing)
 
 -- Same as store, but takes a path to a directory to import
 storeDirectory :: IsRepo a => a -> FilePath -> IO File
@@ -341,6 +340,6 @@ storeDirectory repo path = do
 -- Returns the checksum of the commit.
 withTransaction :: IsRepo a => a -> (a -> IO b) -> IO b
 withTransaction repo fn =
-    bracket_ (repoPrepareTransaction repo noCancellable)
-             (repoCommitTransaction repo noCancellable)
-             (fn repo)
+    CEL.bracket_ (repoPrepareTransaction repo noCancellable)
+                 (repoCommitTransaction repo noCancellable)
+                 (fn repo)

--- a/src/BDCS/Export/Ostree.hs
+++ b/src/BDCS/Export/Ostree.hs
@@ -27,7 +27,7 @@ import           Control.Monad.Except(MonadError)
 import           Control.Monad.IO.Class(MonadIO, liftIO)
 import           Control.Monad.Logger(MonadLoggerIO, logDebugN, logInfoN)
 import           Control.Monad.Trans(lift)
-import           Control.Monad.Trans.Control(MonadBaseControl)
+import           Control.Monad.Trans.Control(MonadBaseControl, liftBaseOp)
 import           Control.Monad.Trans.Resource(MonadResource, runResourceT)
 import           Crypto.Hash(SHA256(..), hashInitWith, hashFinalize, hashUpdate)
 import qualified Data.ByteString as BS (readFile)
@@ -239,9 +239,9 @@ ostreeSink outPath = do
     -- MonadThrow and MonadMask.  This allows logging the call to dracut like we do everything
     -- else without having to think about adding those constraints to quite a lot of code.
     withTempDirectory' :: (MonadBaseControl IO m, MonadLoggerIO m) => FilePath -> String -> (FilePath -> m a) -> m a
-    withTempDirectory' target template =
-        CEL.bracket (liftIO $ createTempDirectory target template)
-                    (\path -> liftIO (removePathForcibly path) `CEL.catch` (\(_ :: CEL.SomeException) -> return ()))
+    withTempDirectory' target template = liftBaseOp $
+        CEL.bracket (createTempDirectory target template)
+                    (\path -> removePathForcibly path `CEL.catch` (\(_ :: CEL.SomeException) -> return ()))
 
     renameDirs :: FilePath -> IO ()
     renameDirs exportDir = do


### PR DESCRIPTION
Doing so requires adding our own withTempDirectory function because this
doesn't require sprinkling MonadMask constraints all over the place.
I'm not really familiar with that so I don't know what adding it will
break.  This way is a little lamer, but not difficult.