### PR TITLE
Stop uploading artifacts to Amazon S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,6 @@ ci_after_success:
 	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs/ \
 	    --env "TRAVIS=$$TRAVIS" --env "TRAVIS_JOB_ID=$$TRAVIS_JOB_ID" --entrypoint /usr/bin/make welder/bdcs-build-img coveralls
 
-	# upload artifacts on which other test activities depend
-	s3cmd sync -v -P ./bdcs/dist/build/bdcs-import/bdcs-import s3://weldr/bdcs-import
-	s3cmd sync -v -P ./bdcs/dist/build/bdcs-export/bdcs-export s3://weldr/bdcs-export
-
 coveralls: sandbox
 	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
 	.cabal-sandbox/bin/hpc-coveralls --display-report test-bdcs bdcs


### PR DESCRIPTION
because we no longer need them. bdcs is installed via RPM.