### PR TITLE
Configure pre-release dependencies for Jenkins

### DIFF
--- a/.jenkins/configure-pre-release-dependencies
+++ b/.jenkins/configure-pre-release-dependencies
@@ -1,0 +1,24 @@
+#!/bin.bash
+# This script will configure the cabal sandbox to
+# use pre-release versions of codec-rpm/content-store tarballs
+# instead of downloading from Hackage.
+#
+# It must be executed from the main project directory!
+#
+# This script is executed by Jenkins when an upstream artifact
+# is present.
+#
+# For bdcs upstream dependencies are codec-rpm and content-store!
+
+cabal update
+cabal sandbox init
+
+
+for dependency in codec-rpm content-store; do
+    tarball="$dependency-latest.tar.gz"
+    if [ -f "$tarball" ]; then
+        tar -xzvf tarball
+        dir_name=`readlink -f $dependency-*/`
+        cabal sandbox add-source $dir_name
+    fi
+done

--- a/bdcs.cabal
+++ b/bdcs.cabal
@@ -32,6 +32,7 @@ extra-source-files:     ChangeLog.md,
                         src/tests/BDCS/Export/*.hs,
                         src/tests/BDCS/RPM/*.hs,
                         tests/*.sh
+                        .jenkins/configure-pre-release-dependencies
 
 source-repository       head
     type:               git


### PR DESCRIPTION
if Jenkins was given an upstream artifact it will download it.
Now it's up to bdcs to configure its sandbox to that cabal build
will use the local sources instead of downloading them from
Hackage.