### PR TITLE
Call .jenkins/configure-pre-release-dependencies from Makefile

### DIFF
--- a/.jenkins/configure-pre-release-dependencies
+++ b/.jenkins/configure-pre-release-dependencies
@@ -5,14 +5,10 @@
 #
 # It must be executed from the main project directory!
 #
-# This script is executed by Jenkins when an upstream artifact
-# is present.
+# Jenkins is responsible for downloading all the upstream
+# artifacts to the local directory.
 #
 # For bdcs upstream dependencies are codec-rpm and content-store!
-
-cabal update
-cabal sandbox init
-
 
 for dependency in codec-rpm content-store; do
     tarball="$dependency-latest.tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ coveralls: sandbox
 	.cabal-sandbox/bin/hpc-coveralls --display-report test-bdcs bdcs
 
 sandbox:
-	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
+	cabal sandbox init && cabal update && .jenkins/configure-pre-release-dependencies
 
 hlint:
 	if [ -z "$$(which hlint)" ]; then \


### PR DESCRIPTION
- this script needs to be executed within the container running
  the tests
- also don't check for .cabal-sandbox/ directory existence in
  Makefile. That was from an older idea before the current script
  was implemented.